### PR TITLE
put embedded cassandra in hawkular services if built with embeddedc profile

### DIFF
--- a/RUNNING.adoc
+++ b/RUNNING.adoc
@@ -2,7 +2,9 @@ To get started with Hawkular Services, you'll need to download the latest distri
 an user and set the Agent to use this password.
 
 You'll also need a Cassandra server up and running. Please, refer to Cassandra's official instructions on how to set
-it up.
+it up. NOTE: If you build your own Hawkular Services distribution, you do not need to install and run Cassandra
+yourself if you build with the -Pembeddedc Maven profile, which deploys an embedded Cassandra node within the
+Hawkular Services server itself.
 
 The following script shows how to accomplish all those steps. Please, don't use this script to setup a production
 instance, as it has several flaws (like catching error conditions, insecure password setting, ...).

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -31,6 +31,11 @@
 
   <name>Hawkular Services Feature Pack</name>
 
+  <properties>
+    <hawkular.embeddedc>false</hawkular.embeddedc>
+    <feature-pack-build-xml>feature-pack-build.xml</feature-pack-build-xml>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.hawkular.services</groupId>
@@ -194,6 +199,10 @@
                       <name>hawkular.agent.enabled</name>
                       <value>${hawkular.agent.enabled}</value>
                     </parameter>
+                    <parameter>
+                      <name>hawkular.embeddedc</name>
+                      <value>${hawkular.embeddedc}</value>
+                    </parameter>
                   </parameters>
                   <includes>
                     <include>configuration/standalone/template.xml</include>
@@ -284,6 +293,7 @@
               <goal>build</goal>
             </goals>
             <configuration>
+              <config-file>${feature-pack-build-xml}</config-file>
               <resources-dir>target/feature-pack-resources</resources-dir>
             </configuration>
           </execution>
@@ -343,6 +353,10 @@
                           <name>hawkular.agent.enabled</name>
                           <value>${hawkular.agent.enabled}</value>
                         </parameter>
+                        <parameter>
+                          <name>hawkular.embeddedc</name>
+                          <value>${hawkular.embeddedc}</value>
+                        </parameter>
                         <!-- with the default user in the dev profile -->
                         <parameter>
                           <name>hawkular.rest.user</name>
@@ -373,6 +387,48 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <!-- A profile to build a distro that includes embedded cassandra -->
+      <id>embeddedc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.hawkular.commons</groupId>
+          <artifactId>hawkular-commons-embedded-cassandra-war</artifactId>
+          <type>war</type>
+        </dependency>
+      </dependencies>
+      <properties>
+        <hawkular.embeddedc>true</hawkular.embeddedc>
+        <feature-pack-build-xml>target/feature-pack-config/feature-pack-build.xml</feature-pack-build-xml>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-feature-pack-build-xml-with-embedded-cassandra</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <copy file="${basedir}/feature-pack-build.xml" tofile="${feature-pack-build-xml}" />
+                    <replaceregexp file="${feature-pack-build-xml}"
+                                   match="&lt;/copy-artifacts>"
+                                   replace="  &lt;copy-artifact artifact=&quot;org.hawkular.commons:hawkular-commons-embedded-cassandra-war&quot; to-location=&quot;modules/system/layers/hawkular/org/hawkular/nest/main/deployments/hawkular-commons-embedded-cassandra-war.war&quot; />&#10;  &lt;/copy-artifacts>" />
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
 
 </project>

--- a/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-template.xsl
+++ b/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-template.xsl
@@ -25,6 +25,7 @@
   <xsl:param name="hawkular.agent.enabled" select="'true'"/>
   <xsl:param name="hawkular.rest.user" select="''"/>
   <xsl:param name="hawkular.rest.password" select="''"/>
+  <xsl:param name="hawkular.embeddedc" select="'false'"/>
 
   <!-- Add the default user and password if they were passed in through the parameters -->
   <xsl:template match="/*[local-name()='server']/*[local-name()='management']">
@@ -44,6 +45,12 @@
         <xsl:element name="property" namespace="{namespace-uri()}">
           <xsl:attribute name="name">hawkular.rest.password</xsl:attribute>
           <xsl:attribute name="value">${hawkular.rest.password:<xsl:value-of select="$hawkular.rest.password" />}</xsl:attribute>
+        </xsl:element>
+      </xsl:if>
+      <xsl:if test="$hawkular.embeddedc = 'true'">
+        <xsl:element name="property" namespace="{namespace-uri()}">
+          <xsl:attribute name="name">hawkular.backend</xsl:attribute>
+          <xsl:attribute name="value">embedded_cassandra</xsl:attribute>
         </xsl:element>
       </xsl:if>
     </system-properties>


### PR DESCRIPTION
This reintroduces the ability to build Hawkular Services with Embedded Cassandra.

You can do this via -Pembeddedc Maven profile.

This feature allows an easier "on ramp" for you developers or folks that want to demo - no need to install and start a separate Cassandra server (no need to even know that you have to do it).