### PR TITLE
Adding hawkular-tenant headers for the URL rest api. 

### DIFF
--- a/hawkular-rest/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/impl/RestURLImpl.java
+++ b/hawkular-rest/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/impl/RestURLImpl.java
@@ -98,8 +98,12 @@ public class RestURLImpl extends RestBase implements RestURL {
                 createUrlCommandInjector.select(Initialized.withValues(url.getUrl(), authToken, tenantId)).get();
         Observable<String> observer = createUrlCommand.toObservable();
         observer.subscribe((commandResponse) -> {
-            URI uri = URI.create(commandResponse);
-            asyncResponse.resume(Response.created(uri).build());
+            if (commandResponse != null) {
+                URI uri = URI.create(commandResponse);
+                asyncResponse.resume(Response.created(uri).build());
+            } else {
+                asyncResponse.resume(Response.ok("Url " + url + " already exists.").build());
+            }
         });
     }
 

--- a/hawkular-rest/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/HawkularConfiguration.java
+++ b/hawkular-rest/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/HawkularConfiguration.java
@@ -28,7 +28,7 @@ public class HawkularConfiguration {
     public static final String URL_ACCOUNTS = "http://127.0.0.1:8080/hawkular/accounts";
     public static final String URL_BTM = "http://127.0.0.1:8080/hawkular/btm";
     public static final String URL_ALERTS = "http://127.0.0.1:8080/hawkular/alerts";
-    public static final String URL_INVENTORY = "http://127.0.0.1:8080/hawkular/inventory";
+    public static final String URL_INVENTORY = "http://127.0.0.1:8080/hawkular/inventory/deprecated";
     public static final String URL_METRICS = "http://127.0.0.1:8080/hawkular/metrics";
 
 

--- a/hawkular-rest/hawkular-rx/src/main/java/org/hawkular/rx/httpclient/OkClient.java
+++ b/hawkular-rest/hawkular-rx/src/main/java/org/hawkular/rx/httpclient/OkClient.java
@@ -42,6 +42,7 @@ public class OkClient implements HttpClient {
                 .url(url)
                 .addHeader("Authorization", authToken)
                 .addHeader("Hawkular-Persona", persona)
+                .addHeader("Hawkular-Tenant", "hawkular")
                 .post(body)
                 .build();
 //        this.delegatingClient.interceptors().add(null);
@@ -66,6 +67,7 @@ public class OkClient implements HttpClient {
                 .url(url)
                 .addHeader("Authorization", authToken)
                 .addHeader("Hawkular-Persona", persona)
+                .addHeader("Hawkular-Tenant", "hawkular")
                 .get()
                 .build();
 
@@ -79,6 +81,7 @@ public class OkClient implements HttpClient {
                 .url(url)
                 .addHeader("Authorization", authToken)
                 .addHeader("Hawkular-Persona", persona)
+                .addHeader("Hawkular-Tenant", "hawkular")
                 .put(body)
                 .build();
 
@@ -91,6 +94,7 @@ public class OkClient implements HttpClient {
                 .url(url)
                 .addHeader("Authorization", authToken)
                 .addHeader("Hawkular-Persona", persona)
+                .addHeader("Hawkular-Tenant", "hawkular")
                 .delete()
                 .build();
 


### PR DESCRIPTION
MiQ ruby client calls this during the tests - https://github.com/hawkular/hawkular-client-ruby/blob/master/spec/integration/inventory_spec.rb#L92:L102

@lucasponce could you please review? This is one of the reasons why the specs were failing against the live services.