### PR TITLE
Add Maven profile to the docker dist module which creates zip

### DIFF
--- a/docker-dist/pom.xml
+++ b/docker-dist/pom.xml
@@ -212,5 +212,35 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>docker-dist-zip</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>assemble-docker-files</id>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <formats>
+                    <format>zip</format>
+                  </formats>
+                  <descriptors>
+                    <descriptor>src/main/docker/docker-assembly.xml</descriptor>
+                  </descriptors>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/docker-dist/src/main/docker/docker-assembly.xml
+++ b/docker-dist/src/main/docker/docker-assembly.xml
@@ -21,6 +21,8 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
+  <id>docker-dist</id>
+
   <dependencySets>
     <dependencySet>
       <includes>


### PR DESCRIPTION
The profile is off by default.  When activated it creates a zip
of the hawkular files which can be added to a wildfly or eap instance.
This is useful in case you have a separate docker build and you want just the
hawkular files to layer onto wildfly/eap.