### PR TITLE
HAWKULAR-1121 Fix wrong path on MetricsAlerting itest

### DIFF
--- a/itest/src/test/java/org/hawkular/services/rest/test/MetricsAlertingITest.java
+++ b/itest/src/test/java/org/hawkular/services/rest/test/MetricsAlertingITest.java
@@ -132,7 +132,7 @@ public class MetricsAlertingITest extends AbstractTestBase {
 
         /* Check if we have generated an event */
         testClient.newRequest()
-                .path(gaugePath)
+                .path(eventsTriggerPath)
                 .get()
                 .assertWithRetries(testResponse -> {
                     testResponse

--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,10 @@
   <properties>
     <version.javaee.spec>7.0</version.javaee.spec>
     <version.org.hawkular.agent>0.21.0.Final</version.org.hawkular.agent>
-    <version.org.hawkular.alerts>1.1.3.Final</version.org.hawkular.alerts>
+    <version.org.hawkular.alerts>1.1.4.Final</version.org.hawkular.alerts>
     <version.org.hawkular.commons>0.7.8.Final</version.org.hawkular.commons>
     <version.org.hawkular.inventory>0.18.0.Final</version.org.hawkular.inventory>
-    <version.org.hawkular.metrics>0.19.0.Final</version.org.hawkular.metrics>
+    <version.org.hawkular.metrics>0.19.2.Final</version.org.hawkular.metrics>
 
     <version.org.jboss.arquillian>1.1.11.Final</version.org.jboss.arquillian>
     <version.ch.qos.logback>1.1.3</version.ch.qos.logback>


### PR DESCRIPTION
This PR needs a release of metrics and alerting.
The bug on the itest masked some issues on the intregation side.

I will update the PR once these releases are out.

Please don't merge as pom.xml is provisional.