### PR TITLE
Bump to inventory 0.19.2.Final and agent to 0.22.0.Final.

### DIFF
--- a/feature-pack/feature-pack-build.xml
+++ b/feature-pack/feature-pack-build.xml
@@ -21,6 +21,7 @@
   <dependencies>
     <artifact name="org.hawkular.commons:hawkular-nest-feature-pack" />
     <artifact name="org.hawkular.agent:hawkular-wildfly-agent-feature-pack" />
+    <artifact name="org.hawkular.inventory:hawkular-inventory-feature-pack" />
   </dependencies>
 
   <config>
@@ -37,7 +38,6 @@
 
     <copy-artifact artifact="org.hawkular.alerts:hawkular-alerts-actions-email" to-location="modules/system/layers/hawkular/org/hawkular/nest/main/deployments/hawkular-alerts-actions-email.war" />
     <copy-artifact artifact="org.hawkular.alerts:hawkular-alerts-rest" to-location="modules/system/layers/hawkular/org/hawkular/nest/main/deployments/hawkular-alerts-rest.war" />
-    <copy-artifact artifact="org.hawkular.inventory:hawkular-inventory-dist" to-location="modules/system/layers/hawkular/org/hawkular/nest/main/deployments/hawkular-inventory-dist.war" />
     <copy-artifact artifact="org.hawkular.metrics:hawkular-metrics-component" to-location="modules/system/layers/hawkular/org/hawkular/nest/main/deployments/hawkular-metrics-component.war" />
   </copy-artifacts>
 

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -94,8 +94,8 @@
 
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
-      <artifactId>hawkular-inventory-dist</artifactId>
-      <type>war</type>
+      <artifactId>hawkular-inventory-feature-pack</artifactId>
+      <type>zip</type>
     </dependency>
 
     <dependency>
@@ -144,6 +144,14 @@
                 <artifactItem>
                   <groupId>org.hawkular.agent</groupId>
                   <artifactId>hawkular-wildfly-agent-feature-pack</artifactId>
+                  <type>zip</type>
+                  <includes>subsystem-templates/*.xml,configuration/**/*.xml</includes>
+                  <outputDirectory>${project.build.directory}/feature-pack-resources</outputDirectory>
+                </artifactItem>
+
+                <artifactItem>
+                  <groupId>org.hawkular.inventory</groupId>
+                  <artifactId>hawkular-inventory-feature-pack</artifactId>
                   <type>zip</type>
                   <includes>subsystem-templates/*.xml,configuration/**/*.xml</includes>
                   <outputDirectory>${project.build.directory}/feature-pack-resources</outputDirectory>

--- a/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-subsystems.xsl
+++ b/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-subsystems.xsl
@@ -40,6 +40,11 @@
     <subsystem>hawkular-services-logging.xml</subsystem>
   </xsl:template>
 
+  <!-- Replace datasources.xml with hawkular-inventory-datasources.xml -->
+  <xsl:template match="/*[local-name()='config']/*[local-name()='subsystems']/*[local-name()='subsystem' and text()='datasources.xml']">
+    <subsystem>hawkular-inventory-datasources.xml</subsystem>
+  </xsl:template>
+
   <!-- Replace infinispan.xml with hawkular-services-infinispan.xml -->
   <xsl:template match="/*[local-name()='config']/*[local-name()='subsystems']/*[local-name()='subsystem' and text()='infinispan.xml']">
     <xsl:copy>

--- a/itest/src/test/java/org/hawkular/services/rest/test/AgentITest.java
+++ b/itest/src/test/java/org/hawkular/services/rest/test/AgentITest.java
@@ -178,7 +178,7 @@ public class AgentITest extends AbstractTestBase {
 
                             });
 
-                }, Retry.times(50).delay(1000));
+                }, Retry.times(500).delay(1000));
 
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,10 @@
 
   <properties>
     <version.javaee.spec>7.0</version.javaee.spec>
-    <version.org.hawkular.agent>0.21.0.Final</version.org.hawkular.agent>
+    <version.org.hawkular.agent>0.22.0.Final</version.org.hawkular.agent>
     <version.org.hawkular.alerts>1.1.4.Final</version.org.hawkular.alerts>
     <version.org.hawkular.commons>0.7.8.Final</version.org.hawkular.commons>
-    <version.org.hawkular.inventory>0.18.0.Final</version.org.hawkular.inventory>
+    <version.org.hawkular.inventory>0.19.2.Final</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.19.3.Final</version.org.hawkular.metrics>
 
     <version.org.jboss.arquillian>1.1.11.Final</version.org.jboss.arquillian>
@@ -177,9 +177,9 @@
 
       <dependency>
         <groupId>org.hawkular.inventory</groupId>
-        <artifactId>hawkular-inventory-dist</artifactId>
+        <artifactId>hawkular-inventory-feature-pack</artifactId>
         <version>${version.org.hawkular.inventory}</version>
-        <type>war</type>
+        <type>zip</type>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
These two should work well together and let the services itests pass.

Modify the build to include the datasources and jdbc drivers from the inventory feature-pack.