### PR TITLE
After succesfully testing, try to test hawkular-client-ruby.

### DIFF
--- a/.travis.hawkular-client.ruby.sh
+++ b/.travis.hawkular-client.ruby.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -xe
+
+if [ "$TRAVIS_PULL_REQUEST" = false ] ; then
+    exit
+fi
+
+function post_comment {
+    set +x
+    echo 'Sending comment to github.'
+    curl -s -H "Authorization: token $GITHUB_TOKEN"  \
+    -i "https://api.github.com/repos/$TRAVIS_REPO_SLUG/issues/$TRAVIS_PULL_REQUEST/comments"  \
+    --data  "{\"body\": \"$1\"}" > /dev/null
+    set -x
+}
+
+# Create docker image.
+mvn -s .travis.maven.settings.xml -Pdev,dozip clean install
+pushd docker-dist
+mvn -s ../.travis.maven.settings.xml docker:build
+popd
+
+# Download hawkular-client-ruby and make it ready.
+git clone --depth 1 https://github.com/hawkular/hawkular-client-ruby.git
+pushd hawkular-client-ruby
+bundle install
+sed -i "s/  image: .*hawkular-services/  image: \"`whoami`\/hawkular-services/g" docker-compose.yml
+docker-compose up -d && ./.travis/wait_for_services.rb && \
+sleep 20s
+
+RUN_ON_LIVE_SERVER=1 \
+VCR_UPDATE=1 \
+SKIP_SSL_WITHOUT_CERTIFICATE_TEST=1 \
+SKIP_SECURE_CONTEXT=1 \
+SKIP_V8_METRICS=1 \
+SKIP_SERVICES_METRICS=1 \
+bundle exec rspec && \
+post_comment 'This PR seem to be working well with [hawkular-client-ruby](https://github.com/hawkular/hawkular-client-ruby) :+1:.' ||
+post_comment 'This PR potentially fails with [hawkular-client-ruby](https://github.com/hawkular/hawkular-client-ruby).'
+docker-compose kill
+popd

--- a/.travis.install.maven.sh
+++ b/.travis.install.maven.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+set -xe
+
+MVN_VERSION="$1"
+MVN_INSTALL_DIR="$2"
+
+if [ ! -f "${MVN_INSTALL_DIR}/lib/maven-artifact-${MVN_VERSION}.jar" ]; then
+  # remove the older version that can eventually be there
+  rm -Rf "${MVN_INSTALL_DIR}"
+  mkdir -p "${MVN_INSTALL_DIR}"
+
+  # Find the closest Apache mirror
+  APACHE_MIRROR="$(curl -sL https://www.apache.org/dyn/closer.cgi?asjson=1 | python -c 'import sys, json; print json.load(sys.stdin)["preferred"]')"
+  curl -o "${HOME}/apache-maven-$MVN_VERSION-bin.tar.gz" "$APACHE_MIRROR/maven/maven-3/$MVN_VERSION/binaries/apache-maven-$MVN_VERSION-bin.tar.gz"
+  cd "${MVN_INSTALL_DIR}"
+  tar -xzf "${HOME}/apache-maven-$MVN_VERSION-bin.tar.gz" --strip 1
+  chmod +x "${MVN_INSTALL_DIR}/bin/mvn"
+else
+  echo "Using cached Maven ${MVN_VERSION}"
+fi
+${MVN_INSTALL_DIR}/bin/mvn -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
+sudo: required
+dist: trusty
+
 language: java
-# Enable container-based infrastructure
-# see http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
+services:
+  - docker
+
+env:
+  global:
+    - secure: "d7jJmEFMcdJv7UiGhvrOJF/1zOjLpC1vaMrNtOWXoM6DmnC+Jmg9wdeyex6eUziBpVvbZKOc0mJ9Kk2ITKNgN1hDWaY+RuoDKY2+OfPRyiLQbFaKL6xc5gKVlCFKrP8//0XNXhzkKDeOogp8mx+cA0G+wuN7H6NhTC7hYUxANpQJ2P2WzCH7HYaqMP6VF2kq2jEipAmlwVWUgi+wSG9+SW+8DU1Jus9mJygshC7GzE9Ym+Asy0Rzi06BcVUl29/dP9DpA0Jq59bM8nAyIth9mRtS2MUsycJM6FOt4NppzOzdQygRd8mP7mSPv2KeOT7brFdMiRi+2CHcuNA8cZzBZgiJmA9yNt1BNObu1mTTJY3mYefZgvnl/Duz4ggFr79T4zqtt93Eu3K1O0EKsSWrugA3ZVO6sRI7TLeSjaXv1idO4iXJ7DoLgks2PwtuKke20qRDzK7g5LdqmyKA+TG2vSsUvGzeUOfLpvHCi9y+p9wLlpULSxsTRFf2EiHisBGZn/Vs6to6JGDVoJQDpD0bTHux/Kmmq/ZS+LDcfgPLUdgXltoTTTsgT97iocVCGXH0+Dz6dEoptVTXyQOGGZXD3KUbh5KcyTi4Gmiowt5z3OvxCYxmVyD/tpzj0cMwPTh4x0aEoyHNC/yUmLraSLbNxYKlc7OSKfh9WDDk5L7RwPM="
 
 # manage the caches here https://travis-ci.org/hawkular/hawkular-services/caches
 cache:
@@ -18,6 +24,9 @@ notifications:
     on_success: change
 
 install:
+- bash .travis.install.maven.sh "3.3.9" "${HOME}/mvn-home"
+- export M2_HOME=${HOME}/mvn-home
+- export PATH=${HOME}/mvn-home/bin:${PATH}
 - mvn -version -B
 # unshallow is needed by license-maven-plugin
 - git fetch origin --unshallow || true
@@ -25,6 +34,9 @@ install:
 script:
 - mvn -s .travis.maven.settings.xml verify -Pitest -Dfailsafe.useFile=false | grep -vF "[INFO] Downloading:" | grep
   -vF "[INFO] Downloaded:"; test ${PIPESTATUS[0]} -eq 0
+
+after_success:
+- bash .travis.hawkular-client.ruby.sh
 
 before_cache:
 # Clean the cached directories once their size exceeds the space left on the partition.


### PR DESCRIPTION
Added testing of hawkular-client-ruby on every hawkular-services PR.

To so I had to drop some .travis.yml features (Disabled container-based infrastructure) and installing maven by hand (the script is borrowed from other hawkular projects).

The testing of hawkular-client-ruby shouldn't affect the hawkular-services test itself, as is on an after_success. It would only fail if the build stalled for some reason see [this](https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build) for more info.

See [here](https://github.com/josejulio/hawkular-services/pull/1) for an example of how it would report errors on the hawkular-client-ruby.