### PR TITLE
Bump inventory to 1.0.2.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <version.org.hawkular.agent>0.24.0.Final</version.org.hawkular.agent>
     <version.org.hawkular.alerts>1.3.1.Final</version.org.hawkular.alerts>
     <version.org.hawkular.commons>0.7.10.Final</version.org.hawkular.commons>
-    <version.org.hawkular.inventory>1.0.1.Final</version.org.hawkular.inventory>
+    <version.org.hawkular.inventory>1.0.2.Final</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.21.2.Final</version.org.hawkular.metrics>
     <version.org.jboss.arquillian>1.1.11.Final</version.org.jboss.arquillian>
     <version.ch.qos.logback>1.1.3</version.ch.qos.logback>


### PR DESCRIPTION
I forgot to include the hsqldb memory consumption settings in `1.0.1.Final`. Mea culpa :disappointed: .
`1.0.2.Final` fixes that (and just that) but I guess it is too late for this week's services. Sorry for that..