### PR TITLE
ActiveMQ isn't able to create another thread when running in docker.

### DIFF
--- a/docker-dist/README.adoc
+++ b/docker-dist/README.adoc
@@ -28,4 +28,4 @@ By default, this will create a docker image with the name "<username>/hawkular-s
 
 Next, start up the hawkular services container and point it to the Cassandra instance.
 
-  docker run --link=hawkular-cassandra -e CASSANDRA_NODES=hawkular-cassandra <username>/hawkular-services
+  docker run --link=hawkular-cassandra -e CASSANDRA_NODES=hawkular-cassandra -p 8080:8080 <username>/hawkular-services

--- a/docker-dist/src/main/resources/startcmd.sh
+++ b/docker-dist/src/main/resources/startcmd.sh
@@ -23,6 +23,7 @@ ${AS_ROOT}/bin/standalone.sh -b 0.0.0.0 \
        -Djboss.server.name=${HOSTNAME} \
        -Djboss.server.data.dir=/opt/data/data \
        -Djboss.server.log.dir=/opt/data/log \
+       -Dactivemq.artemis.client.global.thread.pool.max.size=${HAWKULAR_JMS_THREAD_POOL:-30} \
        -Dhawkular.agent.enabled=${HAWKULAR_AGENT_ENABLE} \
        -Dhawkular.rest.user=${HAWKULAR_USER} \
        -Dhawkular.rest.password=${HAWKULAR_PASSWORD} \


### PR DESCRIPTION
By default it creates ~500 threads so lets reduce that number to 30. I haven't experienced any perf drop by smoke testing.

more info here:
https://developer.jboss.org/thread/268397