### PR TITLE
s/AS.ROOT/JBOSS_HOME/g

### DIFF
--- a/docker-dist/pom.xml
+++ b/docker-dist/pom.xml
@@ -32,10 +32,10 @@
   <properties>
     <docker-plugin.project.version>0.15.8</docker-plugin.project.version>
     <docker.base-image>jboss/wildfly:10.0.0.Final</docker.base-image>
-    <docker.as.root>/opt/jboss/wildfly</docker.as.root>
     <docker.tag.prefix />
     <docker.tag.version>${project.version}</docker.tag.version>
     <docker.java.opts>-Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n</docker.java.opts>
+    <docker.jboss_home>/opt/jboss/wildfly</docker.jboss_home>
     <plexus-utils.version>3.0.15</plexus-utils.version>
     <alpn-boot.version>8.1.7.v20160121</alpn-boot.version>
     <version.cassandra>3.0.9</version.cassandra>
@@ -140,7 +140,6 @@
                   <HAWKULAR_USER>jdoe</HAWKULAR_USER>
                   <HAWKULAR_PASSWORD>password</HAWKULAR_PASSWORD>
                   <HAWKULAR_AGENT_ENABLE>${hawkular.agent.enabled}</HAWKULAR_AGENT_ENABLE>
-                  <AS_ROOT>${docker.as.root}</AS_ROOT>
                   <JAVA_OPTS>${docker.java.opts}</JAVA_OPTS>
                   <HAWKULAR_METRICS_TTL>${hawkular.metrics.ttl}</HAWKULAR_METRICS_TTL>
                 </env>

--- a/docker-dist/src/main/docker/docker-assembly.xml
+++ b/docker-dist/src/main/docker/docker-assembly.xml
@@ -28,26 +28,26 @@
       <includes>
         <include>org.mortbay.jetty.alpn:alpn-boot</include>
       </includes>
-      <outputDirectory>/opt/jboss/wildfly/bin</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/bin</outputDirectory>
     </dependencySet>
   </dependencySets>
 
   <fileSets>
     <fileSet>
       <directory>${project.build.directory}/${project.build.finalName}/modules/system/add-ons/hawkular-agent</directory>
-      <outputDirectory>${docker.as.root}/modules/system/add-ons/hawkular-agent</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/modules/system/add-ons/hawkular-agent</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>${project.build.directory}/${project.build.finalName}/modules/system/layers/hawkular</directory>
-      <outputDirectory>${docker.as.root}/modules/system/layers/hawkular</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/modules/system/layers/hawkular</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>${project.build.directory}/${project.build.finalName}/modules/system/layers/base/org/jboss/as/product/hawkular</directory>
-      <outputDirectory>${docker.as.root}/modules/system/layers/base/org/jboss/as/product/hawkular</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/modules/system/layers/base/org/jboss/as/product/hawkular</outputDirectory>
     </fileSet>
     <fileSet>
       <directory>${project.build.directory}/${project.build.finalName}/hawkular-welcome-content</directory>
-      <outputDirectory>${docker.as.root}/hawkular-welcome-content</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/hawkular-welcome-content</outputDirectory>
     </fileSet>
   </fileSets>
 
@@ -59,27 +59,27 @@
     </file>
     <file>
       <source>${project.build.directory}/${project.build.finalName}/standalone/configuration/standalone.xml</source>
-      <outputDirectory>${docker.as.root}/standalone/configuration</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/standalone/configuration</outputDirectory>
     </file>
     <file>
       <source>${project.build.directory}/${project.build.finalName}/standalone/configuration/hawkular-wildfly-agent-installer.jar</source>
-      <outputDirectory>${docker.as.root}/standalone/configuration</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/standalone/configuration</outputDirectory>
     </file>
     <file>
       <source>${project.build.directory}/${project.build.finalName}/standalone/configuration/hawkular-wildfly-agent-wf-extension.zip</source>
-      <outputDirectory>${docker.as.root}/standalone/configuration</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/standalone/configuration</outputDirectory>
     </file>
     <file>
       <source>${project.build.directory}/${project.build.finalName}/standalone/configuration/hawkular-wildfly-agent-wf-extension-eap6.zip</source>
-      <outputDirectory>${docker.as.root}/standalone/configuration</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/standalone/configuration</outputDirectory>
     </file>
     <file>
       <source>${project.build.directory}/${project.build.finalName}/modules/layers.conf</source>
-      <outputDirectory>${docker.as.root}/modules/</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/modules/</outputDirectory>
     </file>
     <file>
       <source>${project.build.directory}/${project.build.finalName}/bin/product.conf</source>
-      <outputDirectory>${docker.as.root}/bin/</outputDirectory>
+      <outputDirectory>${docker.jboss_home}/bin/</outputDirectory>
     </file>
   </files>
 </assembly>

--- a/docker-dist/src/main/resources/startcmd.sh
+++ b/docker-dist/src/main/resources/startcmd.sh
@@ -17,8 +17,8 @@
 #
 
 echo ${HOSTNAME} > /etc/machine-id
-${AS_ROOT}/bin/add-user.sh -a -u ${HAWKULAR_USER} -p ${HAWKULAR_PASSWORD} -g read-write,read-only
-${AS_ROOT}/bin/standalone.sh -b 0.0.0.0 \
+${JBOSS_HOME}/bin/add-user.sh -a -u ${HAWKULAR_USER} -p ${HAWKULAR_PASSWORD} -g read-write,read-only
+${JBOSS_HOME}/bin/standalone.sh -b 0.0.0.0 \
        -bmanagement 0.0.0.0 \
        -Djboss.server.name=${HOSTNAME} \
        -Djboss.server.data.dir=/opt/data/data \

--- a/docker-dist/src/main/resources/startcmd.sh
+++ b/docker-dist/src/main/resources/startcmd.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
'AS.ROOT' evokes similar meaning as sudo and it has the same content as 'JBOSS_HOME' introduced in the base image.

Unfortunatelly, the `docker.jboss_home` must be still present in the maven build, because that assembly file needs to know where it should copy our built artifact and it doesn't work with env properties that are known inside the container.

It's ok to use the `JBOSS_HOME` even in the EAP context, because the scripts like `add-user.sh` are also using the `JBOSS_HOME` property.


when trying with eap as a base image:
```bash
mvn -Ddocker.base-image=docker-registry.usersys.redhat.com/cloud_enablement/jboss-eap:6.4-63 docker:build docker:run
```

The JBOSS_HOME was taken into consideration during the AS start.

I got this error, when the startcmd.sh was trying to add the user:
```
 * Error * 
JBAS015266: Password must have at least 1 digit.
```

This is because eap has by default strong password policy enabled.
It can be turned off by changing the `add-user.properties` (password.restriction=WARN/RELAX)



If the ^ is fixed then it fails with `Unexpected element '{urn:jboss:domain:4.0}server'`, our knowledge base says:

"We may face this issue if we copy $JBOSS_HOME/modules/system directory from JBoss EAP 6.3 installation to EAP 6.4 installation."

So we are probably installing our agent to EAP that doesn't support that. So I'll try with higher version of EAP (but 7.x is not in the registry :/)