### PR TITLE
Adding a simple readiness bash script

### DIFF
--- a/docker-dist/src/main/docker/docker-assembly.xml
+++ b/docker-dist/src/main/docker/docker-assembly.xml
@@ -58,6 +58,11 @@
       <fileMode>755</fileMode>
     </file>
     <file>
+      <source>src/main/resources/ready.sh</source>
+      <outputDirectory>/opt/hawkular/bin</outputDirectory>
+      <fileMode>755</fileMode>
+    </file>
+    <file>
       <source>src/main/resources/standalone.conf</source>
       <outputDirectory>${docker.jboss_home}/bin</outputDirectory>
       <fileMode>755</fileMode>

--- a/docker-dist/src/main/resources/ready.sh
+++ b/docker-dist/src/main/resources/ready.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# exit codes:
+# 0 ok
+# 1 at least /status is broken
+# 2 at least /metrics/status  is broken
+# 3 at least /alerts/status is broken
+# 4 /inventory/status is broken
+
+i=0
+for path in /status /metrics/status /alerts/status /inventory/status ; do
+  i=$(( $i + 1 ))
+  code=`curl -s -I -o /dev/null -w "%{http_code}" http://$HOSTNAME:8080/hawkular$path` || exit $i
+  [[ "$code" -lt "200" || "$code" -gt "299" ]] && exit $i
+done
+
+# everything is ok
+exit 0


### PR DESCRIPTION
It curls all the /{component}/status e…ndpoints and if all of them are ok, returns 0

If we use this instead of simple [httpGet -> /status](https://github.com/hawkular/hawkular-services/pull/115/files#diff-a37849aeb4d4e33017d0dc579b6231b3R127), it should solve the issue with slow C* start where some components were initialized and come were not.

If some service is not ok, the whole pod would be considered as not ok and killed. In case of slow C*, the next attempt would be successful.