### PR TITLE
Make the /opt/data writable by jboss:jboss

### DIFF
--- a/docker-dist/src/main/docker/Dockerfile
+++ b/docker-dist/src/main/docker/Dockerfile
@@ -24,7 +24,6 @@ ARG metrics_ttl=21
 ARG the_tag
 
 EXPOSE 8080 8443 8787
-VOLUME ["/opt/data"]
 
 COPY maven /
 
@@ -37,10 +36,11 @@ ENV HAWKULAR_BACKEND=cassandra \
 
 
 USER root
-RUN chown -R jboss:0 ${JBOSS_HOME}/standalone && \
-    chmod -R ug+rw ${JBOSS_HOME}/standalone && \
-    chown -R jboss:0 ${JBOSS_HOME}/domain && \
-    chmod -R ug+rw ${JBOSS_HOME}/domain
+RUN mkdir -p /opt/data && \
+    chown -R jboss:jboss ${JBOSS_HOME}/{standalone,domain} /opt/data && \
+    chmod -R ug+rw ${JBOSS_HOME}/{standalone,domain} /opt/data
+
+VOLUME ["/opt/data"]
 
 USER jboss
 CMD /opt/hawkular/bin/startcmd.sh

--- a/docker-dist/src/main/docker/Dockerfile
+++ b/docker-dist/src/main/docker/Dockerfile
@@ -38,7 +38,7 @@ ENV HAWKULAR_BACKEND=cassandra \
 USER root
 RUN mkdir -p /opt/data && \
     chown -R jboss:jboss ${JBOSS_HOME}/{standalone,domain} /opt/data && \
-    chmod -R ug+rw ${JBOSS_HOME}/{standalone,domain} /opt/data
+    chmod -R ugo+rw ${JBOSS_HOME}/{standalone,domain} /opt/data
 
 VOLUME ["/opt/data"]
 

--- a/docker-dist/src/main/resources/startcmd.sh
+++ b/docker-dist/src/main/resources/startcmd.sh
@@ -19,8 +19,8 @@
 ${JBOSS_HOME}/bin/add-user.sh -a -u ${HAWKULAR_USER} -p ${HAWKULAR_PASSWORD} -g read-write,read-only
 ${JBOSS_HOME}/bin/standalone.sh -b 0.0.0.0 \
        -bmanagement 0.0.0.0 \
-       -Djboss.server.data.dir=/opt/data/data \
-       -Djboss.server.log.dir=/opt/data/log \
+       -Djboss.server.data.dir=${HAWKULAR_DATA:-/opt/data}/data \
+       -Djboss.server.log.dir=${HAWKULAR_DATA:-/opt/data}/log \
        -Dactivemq.artemis.client.global.thread.pool.max.size=${HAWKULAR_JMS_THREAD_POOL:-30} \
        -Dhawkular.agent.enabled=${HAWKULAR_AGENT_ENABLE} \
        -Dhawkular.rest.user=${HAWKULAR_USER} \


### PR DESCRIPTION
Although, the ownership of the mounted volume should be preserved from the host machine. 
I.E.
```bash
mkdir /tmp/foo && sudo chown nfsnobody:nfsnobody /tmp/foo
```
and then running..
```bash
docker run -v /tmp/foo:/opt/data ${USER}/hawkular-services:0.34.0.Final-SNAPSHOT ls -ld /opt/data
```
it should return something like 
`drwxrwxr-x. 2 65534 65534 40 Mar  3 14:46 /opt/data`

(65534 ~ nfsnobody)

If the explicit volume mapping with `-v` switch is not used (or in the docker-compose.yaml file the volume mapping is not specified), then the `/opt/data` is owned by the root and the jboss user can't write the log files to it. This PR fixes this implicit case when running the container w/o the explicit volume mapping, so that:

```bash
docker run ${USER}/hawkular-services:0.34.0.Final-SNAPSHOT /usr/bin/touch /opt/data/foo
```

..just works.

This is handy for ephemeral use-cases where we don't care about the data.

Note: it's important that the `VOLUME` directive in the Dockerfile goes after the commands that prepare the directory.