### PR TITLE
Template credentials auto-generation

### DIFF
--- a/openshift/README.adoc
+++ b/openshift/README.adoc
@@ -2,10 +2,15 @@
 Hawkular Services OpenShift Template
 ------------------------------------
 
-Using this template, user should be able to run the Hawkular Services
-in the OpenShift cluster.
+There are currently two OpenShift templates. The first one, called
+`hawkular-services-ephemeral.yaml`, is only for the demo purposes, because
+the data is lost during the restarts. The second one, called
+`hawkular-services-persistent.yaml`, preserves also the data.
 
-To do that, just run:
+Persistent Template
+-------------------
+
+In order to run the Hawkular Services with the persistent template, just run:
 
 [source,bash]
 ----
@@ -16,7 +21,10 @@ NOTE: It asks for the root password because it is necessary for flushing the
       ip tables and creating the directories for persistent volumes.
 
 This runs the Hawkular Services and create two persistent volumes, so
-that you do not lose your data when restarting openshift.
+that you do not lose your data when restarting OpenShift.
+
+Ephemeral Template
+------------------
 
 If you want to start Hawkular Services and you don’t care about your
 data, use:
@@ -34,8 +42,8 @@ TIP: The behavior of the `startEphemeral.sh` script can be customized by environ
 [[prerequisites]]
 Prerequisites
 ~~~~~~~~~~~~~
-
-The `ansible`, `origin-clients`, `python2-dnf` and `libselinux-python` packages should be installed.
+When using the ansible playbook, the `ansible`, `origin-clients`, `python2-dnf` and `libselinux-python` packages should
+ be installed.
 
 ....
 sudo dnf install -y ansible python2-dnf libselinux-python origin-clients
@@ -58,7 +66,7 @@ configuration and restart the docker:
 
 Edit `/etc/sysconfig/docker` or `/etc/docker/daemon.json` depending on
 your docker and run
-`sudo systemctl daemon-reload && sudo systemctl restart docker`.
+`sudo systemctl restart docker`.
 
 [[troubleshooting]]
 Troubleshooting
@@ -76,7 +84,7 @@ help, I had to do:
 
 [source,bash]
 ----
-sudo systemctl stop firewalld.service rpcbind.service rpcbind.socket
+sudo systemctl stop firewalld.service
 ----
 
 You can see the hawkular-services logs by

--- a/openshift/hawkular-services-ansible-vars.yaml
+++ b/openshift/hawkular-services-ansible-vars.yaml
@@ -39,3 +39,9 @@ flush_ip_tables: true
 create_openshift_cluster: true
 
 openshift_use_metrics: false
+
+# if left blank, it will be auto-generated
+hawkular_user: ""
+
+# if left blank, it will be auto-generated
+hawkular_password: ""

--- a/openshift/hawkular-services-ephemeral.yaml
+++ b/openshift/hawkular-services-ephemeral.yaml
@@ -42,9 +42,19 @@ parameters:
 - name: ROUTE_HOSTNAME
   description: Under this hostname the Hawkular Services will be accessible, if left blank a value will be defaulted.
   displayName: Hostname
+- name: HAWKULAR_USER
+  description: Username that is used for accessing the Hawkular Services, if left blank a value will be generated.
+  displayName: Hawkular User
+  from: '[a-zA-Z0-9]{16}'
+  generate: expression
+- name: HAWKULAR_PASSWORD
+  description: Password that is used for accessing the Hawkular Services, if left blank a value will be generated.
+  displayName: Hawkular Password
+  from: '[a-zA-Z0-9]{16}'
+  generate: expression
 labels:
   template: hawkular-services
-message: Credentials for hawkular-services are jdoe:password
+message: Credentials for hawkular-services are ${HAWKULAR_USER}:${HAWKULAR_PASSWORD}
 
 objects:
 - apiVersion: v1
@@ -117,6 +127,10 @@ objects:
             value: remote
           - name: CASSANDRA_NODES
             value: hawkular-cassandra
+          - name: HAWKULAR_USER
+            value: ${HAWKULAR_USER}
+          - name: HAWKULAR_PASSWORD
+            value: ${HAWKULAR_PASSWORD}
           imagePullPolicy: IfNotPresent
           name: hawkular-services
           volumeMounts:

--- a/openshift/hawkular-services-persistent.yaml
+++ b/openshift/hawkular-services-persistent.yaml
@@ -53,9 +53,19 @@ parameters:
 - name: ROUTE_HOSTNAME
   description: Under this hostname the Hawkular Services will be accessible, if left blank a value will be defaulted.
   displayName: Hostname
+- name: HAWKULAR_USER
+  description: Username that is used for accessing the Hawkular Services, if left blank a value will be generated.
+  displayName: Hawkular User
+  from: '[a-zA-Z0-9]{16}'
+  generate: expression
+- name: HAWKULAR_PASSWORD
+  description: Password that is used for accessing the Hawkular Services, if left blank a value will be generated.
+  displayName: Hawkular Password
+  from: '[a-zA-Z0-9]{16}'
+  generate: expression
 labels:
   template: hawkular-services
-message: Credentials for hawkular-services are jdoe:password
+message: Credentials for hawkular-services are ${HAWKULAR_USER}:${HAWKULAR_PASSWORD}
 
 objects:
 - apiVersion: v1
@@ -128,6 +138,10 @@ objects:
             value: remote
           - name: CASSANDRA_NODES
             value: hawkular-cassandra
+          - name: HAWKULAR_USER
+            value: ${HAWKULAR_USER}
+          - name: HAWKULAR_PASSWORD
+            value: ${HAWKULAR_PASSWORD}
           imagePullPolicy: IfNotPresent
           name: hawkular-services
           volumeMounts:

--- a/openshift/playbook.yaml
+++ b/openshift/playbook.yaml
@@ -154,11 +154,11 @@
       register: hawkular_services_address
 
     - name: Get the hawkular-services username
-      shell: sleep 10 && oc get pod -l name=hawkular-services -o 'jsonpath={..env[?(@.name=="HAWKULAR_USER")].value}'
+      shell: oc env dc/hawkular-services --list | grep HAWKULAR_USER | cut -f2 -d'='
       register: real_hawkular_user
 
     - name: Get the hawkular-services password
-      shell: oc get pod -l name=hawkular-services -o 'jsonpath={..env[?(@.name=="HAWKULAR_PASSWORD")].value}'
+      shell: oc env dc/hawkular-services --list | grep HAWKULAR_PASSWORD | cut -f2 -d'='
       register: real_hawkular_password
 
     - name: Print out the hawkular-services address

--- a/openshift/playbook.yaml
+++ b/openshift/playbook.yaml
@@ -124,6 +124,8 @@
         -v HAWKULAR_SERVICES_IMAGE={{ hawkular_services_image }}
         CASSANDRA_IMAGE={{ cassandra_image }}
         ROUTE_HOSTNAME={{ route_hostname }}
+        `[ -z "{{ hawkular_user }}" ] || echo "HAWKULAR_USER={{ hawkular_user }}"` \
+        `[ -z "{{ hawkular_password }}" ] || echo "HAWKULAR_PASSWORD={{ hawkular_password }}"` \
         ROUTE_NAME={{ route_name }}
         | oc create -f -
       register: command_result
@@ -137,7 +139,9 @@
         oc process -f ./hawkular-services-persistent.yaml
         --param HAWKULAR_SERVICES_IMAGE={{ hawkular_services_image }}
         --param CASSANDRA_IMAGE={{ cassandra_image }}
-        --param ROUTE_HOSTNAME= {{ route_hostname }}
+        --param ROUTE_HOSTNAME={{ route_hostname }}
+        `[ -z "{{ hawkular_user }}" ] || echo "--param HAWKULAR_USER={{ hawkular_user }}"` \
+        `[ -z "{{ hawkular_password }}" ] || echo "--param HAWKULAR_PASSWORD={{ hawkular_password }}"` \
         --param ROUTE_NAME={{ route_name }}
         | oc create -f -
       register: command_result
@@ -145,14 +149,23 @@
       failed_when: "'exists' not in command_result.stderr and command_result.rc != 0"
       changed_when: "'exists' not in command_result.stderr"
 
-    - name: Print out the hawkular-services address
+    - name: Get the hawkular-services address
       shell: "oc get route {{ route_name }} | grep {{ route_name }} | awk '{print $2}'"
       register: hawkular_services_address
+
+    - name: Get the hawkular-services username
+      shell: sleep 10 && oc get pod -l name=hawkular-services -o 'jsonpath={..env[?(@.name=="HAWKULAR_USER")].value}'
+      register: real_hawkular_user
+
+    - name: Get the hawkular-services password
+      shell: oc get pod -l name=hawkular-services -o 'jsonpath={..env[?(@.name=="HAWKULAR_PASSWORD")].value}'
+      register: real_hawkular_password
 
     - name: Print out the hawkular-services address
       debug:
         msg:
           - "The hostname for the Hawkular Services service is: http://{{ hawkular_services_address.stdout }}"
-          - "Credentials are jdoe:password"
+          - "Username: {{ real_hawkular_user.stdout }}"
+          - "Password: {{ real_hawkular_password.stdout }}"
           - "It may take a minute or two to spin the containers. Especially if it is pulling the images."
           - "Consider running   watch oc get pod -l name=hawkular-services    ..to find out when it is ready."


### PR DESCRIPTION
With this PR the openshift template generates the username and password for hawkular-services container and passes it as env. variables. Further improvement would be using the openshift secrets for that and read it by the h-services image as files, but I guess we would need a wrapper openshift image for that, because it's too openshift/k8s specific and it shouldn't be in the generic docker image that can be run also in the docker-compose context or plain with the '--link magic'.

It's still possible to pass the username or password as a parameter:
* for ephemeral:
```bash
[HAWKULAR_USER=jdoe] [HAWKULAR_PASSWORD=jdoe] TEMPLATE="./hawkular-services-ephemeral.yaml" ./startEphemeral.sh
```

* for persistent:
```bash
ansible-playbook playbook.yaml --ask-sudo-pass --extra-vars "hawkular_user=jdoe"
```

It also adds some text to readme file about a way how to make from running ephemeral instance a persistent one.