### PR TITLE
[HAWKULAR-1200] - SSL support for hawkular-services docker image

### DIFF
--- a/docker-dist/README.adoc
+++ b/docker-dist/README.adoc
@@ -28,4 +28,8 @@ By default, this will create a docker image with the name "<username>/hawkular-s
 
 Next, start up the hawkular services container and point it to the Cassandra instance.
 
-  docker run --link=hawkular-cassandra -e CASSANDRA_NODES=hawkular-cassandra -p 8080:8080 <username>/hawkular-services
+  docker run --link=hawkular-cassandra -e CASSANDRA_NODES=hawkular-cassandra -p 8080:8080 `whoami`/hawkular-services
+
+TIP: If you want to use Hawkular Services with SSL try this command:
+
+  docker run --link=hawkular-cassandra -e CASSANDRA_NODES=hawkular-cassandra -e HAWKULAR_USE_SSL=true -p 8443:8443 `whoami`/hawkular-services

--- a/docker-dist/src/main/docker/Dockerfile
+++ b/docker-dist/src/main/docker/Dockerfile
@@ -35,10 +35,6 @@ ENV HAWKULAR_BACKEND=cassandra \
     HAWKULAR_USE_SSL=false \
     HAWKULAR_METRICS_TTL=${metrics_ttl}
 
-LABEL name=hawkular-services \
-      description=Hawkular-Services all-in-one (including Hawkular Metrics, Hawkular Alerts and Hawkular Inventory).
-
-
 USER root
 RUN yum install --quiet -y openssl && \
     rm -rf /var/cache/yum && \

--- a/docker-dist/src/main/docker/Dockerfile
+++ b/docker-dist/src/main/docker/Dockerfile
@@ -32,11 +32,17 @@ ENV HAWKULAR_BACKEND=cassandra \
     HAWKULAR_AGENT_ENABLE=${agent_enable} \
     CASSANDRA_NODES=myCassandra \
     HAWKULAR_USER=jdoe \
+    HAWKULAR_USE_SSL=false \
     HAWKULAR_METRICS_TTL=${metrics_ttl}
+
+LABEL name=hawkular-services \
+      description=Hawkular-Services all-in-one (including Hawkular Metrics, Hawkular Alerts and Hawkular Inventory).
 
 
 USER root
-RUN mkdir -p /opt/data && \
+RUN yum install --quiet -y openssl && \
+    rm -rf /var/cache/yum && \
+    mkdir -p /opt/data && \
     chown -R jboss:jboss ${JBOSS_HOME}/{standalone,domain} /opt/data && \
     chmod -R ugo+rw ${JBOSS_HOME}/{standalone,domain} /opt/data
 
@@ -44,4 +50,3 @@ VOLUME ["/opt/data"]
 
 USER jboss
 CMD /opt/hawkular/bin/startcmd.sh
-

--- a/docker-dist/src/main/docker/Dockerfile
+++ b/docker-dist/src/main/docker/Dockerfile
@@ -39,8 +39,8 @@ USER root
 RUN yum install --quiet -y openssl && \
     rm -rf /var/cache/yum && \
     mkdir -p /opt/data && \
-    chown -R jboss:jboss ${JBOSS_HOME}/{standalone,domain} /opt/data && \
-    chmod -R ugo+rw ${JBOSS_HOME}/{standalone,domain} /opt/data
+    chown -R jboss:jboss ${JBOSS_HOME}/{standalone,domain} /opt/data $JAVA_HOME/jre/lib/security/cacerts && \
+    chmod -R ugo+rw ${JBOSS_HOME}/{standalone,domain} /opt/data $JAVA_HOME/jre/lib/security/cacerts
 
 VOLUME ["/opt/data"]
 

--- a/docker-dist/src/main/docker/docker-assembly.xml
+++ b/docker-dist/src/main/docker/docker-assembly.xml
@@ -63,12 +63,21 @@
       <fileMode>755</fileMode>
     </file>
     <file>
+      <source>src/main/resources/cert_utils.sh</source>
+      <outputDirectory>/opt/hawkular/bin</outputDirectory>
+      <fileMode>755</fileMode>
+    </file>
+    <file>
       <source>src/main/resources/standalone.conf</source>
       <outputDirectory>${docker.jboss_home}/bin</outputDirectory>
       <fileMode>755</fileMode>
     </file>
     <file>
       <source>${project.build.directory}/${project.build.finalName}/standalone/configuration/standalone.xml</source>
+      <outputDirectory>${docker.jboss_home}/standalone/configuration</outputDirectory>
+    </file>
+    <file>
+      <source>${project.build.directory}/${project.build.finalName}/standalone/configuration/standalone-ssl.xml</source>
       <outputDirectory>${docker.jboss_home}/standalone/configuration</outputDirectory>
     </file>
     <file>

--- a/docker-dist/src/main/resources/cert_utils.sh
+++ b/docker-dist/src/main/resources/cert_utils.sh
@@ -38,9 +38,9 @@ add_cert_as_trusted() {
 }
 
 # add the security realm, HTTPS listener and turn SSL for agent
-use_ssl_standalone_xml() {
-  # todo: create the ssl-standalone.xml or use sed -i or something clever on xml, or jboss-cli.sh
-  cp ${JBOSS_HOME}/standalone/configuration/ssl-standalone.xml ${JBOSS_HOME}/standalone/configuration/standalone.xml
+use_standalone_ssl_xml() {
+  cp ${JBOSS_HOME}/standalone/configuration/standalone.xml ${JBOSS_HOME}/standalone/configuration/standalone-orig.xml
+  cp ${JBOSS_HOME}/standalone/configuration/standalone-ssl.xml ${JBOSS_HOME}/standalone/configuration/standalone.xml
 }
 
 add_certificate() {

--- a/docker-dist/src/main/resources/cert_utils.sh
+++ b/docker-dist/src/main/resources/cert_utils.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+KEYSTORE_HOME="${JBOSS_HOME}/standalone/configuration"
+
+# creates the empty ${KEYSTORE_HOME}/hawkular.keystore file
+create_empty_keystore() {
+  keytool -genkeypair -keyalg RSA -alias dummy -dname "CN=localhost" -keypass hawkular -storepass hawkular \
+    -keystore ${KEYSTORE_HOME}/hawkular.keystore
+  keytool -delete -alias dummy -storepass hawkular -keystore ${KEYSTORE_HOME}/hawkular.keystore
+}
+
+# add the certificate from the ${KEYSTORE_HOME}/hawkular.keystore file as trusted
+add_cert_as_trusted() {
+  # export the public key from the keystore
+  keytool -export -alias hawkular -file ${KEYSTORE_HOME}/hawkular.cert -storepass hawkular \
+    -keystore ${KEYSTORE_HOME}/hawkular.keystore
+
+  # and import it as a trusted certificate for the current JDK
+  keytool -import -keystore $JAVA_HOME/jre/lib/security/cacerts -alias hawkular -storepass changeit \
+    -file ${KEYSTORE_HOME}/hawkular.cert -noprompt
+  rm ${KEYSTORE_HOME}/hawkular.cert
+}
+
+# add the security realm, HTTPS listener and turn SSL for agent
+use_ssl_standalone_xml() {
+  # todo: create the ssl-standalone.xml or use sed -i or something clever on xml, or jboss-cli.sh
+  cp ${JBOSS_HOME}/standalone/configuration/ssl-standalone.xml ${JBOSS_HOME}/standalone/configuration/standalone.xml
+}
+
+add_certificate() {
+  if [[ ${HAWKULAR_USE_SSL} = "true" ]]; then
+    local _private_key="/client-secrets/hawkular-services-private.key"
+    local _public_key="/client-secrets/hawkular-services-public.pem"
+    local _keypair="/client-secrets/hawkular-services.pkcs12"
+
+    if [[ -f ${_private_key} ]] && [[ -s ${_private_key} ]] && \
+       [[ -f ${_public_key} ]] && [[ -s ${_public_key} ]]; then
+      # private key and certificate given in pem format
+
+      create_empty_keystore
+
+      # convert the external key pair into pkcs12 file
+      openssl pkcs12 -export -out ${KEYSTORE_HOME}/hawkular.pkcs12 -in ${_public_key} -inkey ${_private_key}
+
+      # import the pkcs12 file to the keystore
+      keytool -v -importkeystore -srckeystore ${KEYSTORE_HOME}/hawkular.pkcs12 -srcstoretype PKCS12
+        -destkeystore ${KEYSTORE_HOME}/hawkular.keystore -deststoretype JKS
+      rm ${KEYSTORE_HOME}/hawkular.pkcs12
+
+      # import the external certificate in pem as a trusted certificate for the current JDK
+      keytool -import -keystore $JAVA_HOME/jre/lib/security/cacerts -alias hawkular -storepass changeit \
+       -file ${_public_key} -noprompt
+    elif [[ -f ${_keypair} ]] && [[ -s ${_keypair} ]]; then
+      # pkcs12 case
+
+      create_empty_keystore
+
+      # import the pkcs12 file to the keystore
+      keytool -v -importkeystore -srckeystore ${_keypair} -srcstoretype PKCS12
+        -destkeystore ${KEYSTORE_HOME}/hawkular.keystore -deststoretype JKS
+
+      add_cert_as_trusted
+    else
+      # generate the keystore and the key pair in it
+      # todo: perhaps we don't want to use the localhost but something given by env property (for OpenShift)
+      keytool -genkeypair -keystore ${KEYSTORE_HOME}/hawkular.keystore -alias hawkular \
+       -dname "CN=localhost" -keyalg RSA -keysize 4096 -storepass hawkular \
+       -keypass hawkular -validity 3650 -ext san=ip:127.0.0.1
+
+      add_cert_as_trusted
+    fi
+    use_ssl_standalone_xml
+  fi
+}

--- a/docker-dist/src/main/resources/cert_utils.sh
+++ b/docker-dist/src/main/resources/cert_utils.sh
@@ -78,9 +78,9 @@ add_certificate() {
       add_cert_as_trusted
     else
       # generate the keystore and the key pair in it
-      # todo: perhaps we don't want to use the localhost but something given by env property (for OpenShift)
+      local _dname=${HAWKULAR_HOSTNAME:-"localhost"}
       keytool -genkeypair -keystore ${KEYSTORE_HOME}/hawkular.keystore -alias hawkular \
-       -dname "CN=localhost" -keyalg RSA -keysize 4096 -storepass hawkular \
+       -dname "CN=${_dname}" -keyalg RSA -keysize 4096 -storepass hawkular \
        -keypass hawkular -validity 3650 -ext san=ip:127.0.0.1
 
       add_cert_as_trusted

--- a/docker-dist/src/main/resources/cert_utils.sh
+++ b/docker-dist/src/main/resources/cert_utils.sh
@@ -81,10 +81,15 @@ add_certificate() {
       add_cert_as_trusted
     else
       # generate the keystore and the key pair in it
+      echo "------------------------------------"
+      echo "Generating the self-signed certificate"
       local _dname=${HAWKULAR_HOSTNAME:-${HOSTNAME:-"localhost"}}
       keytool -genkeypair -keystore ${KEYSTORE_HOME}/hawkular.keystore -alias hawkular \
         -dname "CN=${_dname}" -keyalg RSA -keysize 4096 -storepass hawkular \
         -keypass hawkular -validity 3650 -ext san=ip:127.0.0.1
+
+      keytool -list -keystore ${KEYSTORE_HOME}/hawkular.keystore -storepass hawkular | grep fingerprint
+      echo "------------------------------------"
 
       add_cert_as_trusted
     fi

--- a/docker-dist/src/main/resources/startcmd.sh
+++ b/docker-dist/src/main/resources/startcmd.sh
@@ -79,8 +79,8 @@ run_hawkular_services() {
          -Djboss.server.log.dir=${HAWKULAR_DATA:-/opt/data}/log \
          -Dactivemq.artemis.client.global.thread.pool.max.size=${HAWKULAR_JMS_THREAD_POOL:-30} \
          -Dhawkular.agent.enabled=${HAWKULAR_AGENT_ENABLE} \
-         -Dhawkular.rest.user=${HAWKULAR_USER} \
-         -Dhawkular.rest.password=${HAWKULAR_PASSWORD} \
+         -Dhawkular.rest.user=${username} \
+         -Dhawkular.rest.password=${password} \
          -Dhawkular.metrics.default-ttl=${HAWKULAR_METRICS_TTL:-14} \
          "$@"
 }

--- a/docker-dist/src/main/resources/startcmd.sh
+++ b/docker-dist/src/main/resources/startcmd.sh
@@ -16,13 +16,77 @@
 # limitations under the License.
 #
 
-${JBOSS_HOME}/bin/add-user.sh -a -u ${HAWKULAR_USER} -p ${HAWKULAR_PASSWORD} -g read-write,read-only
-${JBOSS_HOME}/bin/standalone.sh -b 0.0.0.0 \
-       -bmanagement 0.0.0.0 \
-       -Djboss.server.data.dir=${HAWKULAR_DATA:-/opt/data}/data \
-       -Djboss.server.log.dir=${HAWKULAR_DATA:-/opt/data}/log \
-       -Dactivemq.artemis.client.global.thread.pool.max.size=${HAWKULAR_JMS_THREAD_POOL:-30} \
-       -Dhawkular.agent.enabled=${HAWKULAR_AGENT_ENABLE} \
-       -Dhawkular.rest.user=${HAWKULAR_USER} \
-       -Dhawkular.rest.password=${HAWKULAR_PASSWORD} \
-       -Dhawkular.metrics.default-ttl=${HAWKULAR_METRICS_TTL:-14}
+
+get_credentials() {
+  # The username is obtained as a content of file '/client-secrets/hawkular-services.username'
+  # if the file does not exist or is empty, the value of $HAWKULAR_USER is used
+  # if the value of $HAWKULAR_USER is empty, it generates the username
+  # The same precendence rules apply for the password.
+
+  local _username_file="/client-secrets/hawkular-services.username"
+  if [[ -f ${_username_file} && [[ -s ${_username_file} ]] ]]; then
+    username=$(cat ${_username_file})
+  else
+    username=${HAWKULAR_USER:-"$(head /dev/urandom -c 512 | tr -dc A-Z-a-z-0-9 | head -c 16)"}
+  fi
+
+  local _password_file="/client-secrets/hawkular-services.password"
+  if [[ -f ${_password_file} ]] && [[ -s ${_password_file} ]]; then
+    password=$(cat ${_password_file})
+  else
+    password=${HAWKULAR_PASSWORD:-"$(head /dev/urandom -c 512 | tr -dc A-Z-a-z-0-9 | head -c 16)"}
+  fi
+}
+
+create_user() {
+  # we create only if there's users starting with ${username}
+  grep "^${username}" "${JBOSS_HOME}/standalone/configuration/application-users.properties" > /dev/null
+  RT=$?
+
+  if [[ ${RT} -eq 0 ]]; then
+    echo "The '${username}' user has already been found."
+  elif [[ ${RT} -ne 1 ]]; then
+    echo "An error has been found when attempting to check if the '${username}' user exists. Aborting."
+    exit 1
+  else
+    # we add the ${username} user
+    ${JBOSS_HOME}/bin/add-user.sh -a -u "${username}" -p "${password}" -g read-write,read-only -s
+    RT=$?
+    if [[ ${RT} -eq 0 ]]; then
+      echo "------------------------------------"
+      echo "ATTENTION ATTENTION ATTENTION ATTENTION"
+      echo "We automatically created a user for you to access the Hawkular Services:"
+      echo "Username: ${username}"
+      echo "Password: ${password}"
+      echo "------------------------------------"
+    else
+      echo "------------------------------------"
+      echo "ATTENTION ATTENTION ATTENTION ATTENTION"
+      echo "We attempted to create a user for you to access the Hawkular Services,"
+      echo "but for some reason, we didn't succeed. You might need to enter the container manually"
+      echo "and create one user as specified in the documentation."
+      echo "------------------------------------"
+    fi
+  fi
+}
+
+run_hawkular_services() {
+  ${JBOSS_HOME}/bin/standalone.sh -b 0.0.0.0 \
+         -bmanagement 0.0.0.0 \
+         -Djboss.server.data.dir=${HAWKULAR_DATA:-/opt/data}/data \
+         -Djboss.server.log.dir=${HAWKULAR_DATA:-/opt/data}/log \
+         -Dactivemq.artemis.client.global.thread.pool.max.size=${HAWKULAR_JMS_THREAD_POOL:-30} \
+         -Dhawkular.agent.enabled=${HAWKULAR_AGENT_ENABLE} \
+         -Dhawkular.rest.user=${HAWKULAR_USER} \
+         -Dhawkular.rest.password=${HAWKULAR_PASSWORD} \
+         -Dhawkular.metrics.default-ttl=${HAWKULAR_METRICS_TTL:-14} \
+         "$@"
+}
+
+main() {
+  source ./cert_utils.sh
+  get_credentials
+  create_user
+  add_certificate
+  run_hawkular_services "$@"
+}

--- a/docker-dist/src/main/resources/startcmd.sh
+++ b/docker-dist/src/main/resources/startcmd.sh
@@ -86,6 +86,7 @@ run_hawkular_services() {
 }
 
 main() {
+  echo "Starting Hawkular Services"
   source $(dirname "$0")/cert_utils.sh
   get_credentials
   create_user

--- a/feature-pack/feature-pack-build.xml
+++ b/feature-pack/feature-pack-build.xml
@@ -26,6 +26,7 @@
 
   <config>
     <standalone template="configuration/standalone/hawkular-services-template.xml" subsystems="configuration/standalone/hawkular-services-subsystems.xml" output-file="standalone/configuration/standalone.xml" />
+    <standalone template="configuration/standalone/hawkular-services-template-ssl.xml" subsystems="configuration/standalone/hawkular-services-subsystems-ssl.xml" output-file="standalone/configuration/standalone-ssl.xml" />
   </config>
 
   <copy-artifacts>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -201,6 +201,21 @@
 
                 <transformationSet>
                   <dir>${project.build.directory}/feature-pack-resources</dir>
+                  <stylesheet>${basedir}/src/main/xsl/configuration/standalone/hawkular-services-subsystems-ssl.xsl</stylesheet>
+                  <includes>
+                    <include>configuration/standalone/hawkular-services-subsystems.xml</include>
+                  </includes>
+                  <outputDir>${project.build.directory}/feature-pack-resources</outputDir>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
+                      <pattern>^.*$</pattern>
+                      <replacement>configuration/standalone/hawkular-services-subsystems-ssl.xml</replacement>
+                    </fileMapper>
+                  </fileMappers>
+                </transformationSet>
+
+                <transformationSet>
+                  <dir>${project.build.directory}/feature-pack-resources</dir>
                   <stylesheet>${basedir}/src/main/xsl/configuration/standalone/hawkular-services-template.xsl</stylesheet>
                   <!-- without the default user in the default profile -->
                   <parameters>
@@ -221,6 +236,21 @@
                     <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
                       <pattern>^.*$</pattern>
                       <replacement>configuration/standalone/hawkular-services-template.xml</replacement>
+                    </fileMapper>
+                  </fileMappers>
+                </transformationSet>
+
+                <transformationSet>
+                  <dir>${project.build.directory}/feature-pack-resources</dir>
+                  <stylesheet>${basedir}/src/main/xsl/configuration/standalone/hawkular-services-template-ssl.xsl</stylesheet>
+                  <includes>
+                    <include>configuration/standalone/hawkular-services-template.xml</include>
+                  </includes>
+                  <outputDir>${project.build.directory}/feature-pack-resources</outputDir>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
+                      <pattern>^.*$</pattern>
+                      <replacement>configuration/standalone/hawkular-services-template-ssl.xml</replacement>
                     </fileMapper>
                   </fileMappers>
                 </transformationSet>
@@ -281,6 +311,36 @@
                     <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
                       <pattern>^.*$</pattern>
                       <replacement>subsystem-templates/hawkular-services-undertow.xml</replacement>
+                    </fileMapper>
+                  </fileMappers>
+                </transformationSet>
+
+                <transformationSet>
+                  <dir>${project.build.directory}/feature-pack-resources</dir>
+                  <stylesheet>${basedir}/src/main/xsl/subsystem-templates/hawkular-services-undertow-ssl.xsl</stylesheet>
+                  <includes>
+                    <include>subsystem-templates/hawkular-services-undertow.xml</include>
+                  </includes>
+                  <outputDir>${project.build.directory}/feature-pack-resources</outputDir>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
+                      <pattern>^.*$</pattern>
+                      <replacement>subsystem-templates/hawkular-services-undertow-ssl.xml</replacement>
+                    </fileMapper>
+                  </fileMappers>
+                </transformationSet>
+
+                <transformationSet>
+                  <dir>${project.build.directory}/feature-pack-resources</dir>
+                  <stylesheet>${basedir}/src/main/xsl/subsystem-templates/hawkular-wildfly-agent-ssl.xsl</stylesheet>
+                  <includes>
+                    <include>subsystem-templates/hawkular-wildfly-agent.xml</include>
+                  </includes>
+                  <outputDir>${project.build.directory}/feature-pack-resources</outputDir>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
+                      <pattern>^.*$</pattern>
+                      <replacement>subsystem-templates/hawkular-wildfly-agent-ssl.xml</replacement>
                     </fileMapper>
                   </fileMappers>
                 </transformationSet>

--- a/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-subsystems-ssl.xsl
+++ b/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-subsystems-ssl.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xalan="http://xml.apache.org/xalan" version="2.0" exclude-result-prefixes="xalan">
+
+  <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no" />
+
+  <!-- Replace hawkular-wildfly-agent.xml with hawkular-wildfly-agent-ssl.xml -->
+  <xsl:template match="/*[local-name()='config']/*[local-name()='subsystems']/*[local-name()='subsystem' and text()='hawkular-wildfly-agent.xml']">
+    <xsl:copy>
+      <xsl:text>hawkular-wildfly-agent-ssl.xml</xsl:text>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Replace hawkular-undertow.xml with hawkular-services-undertow-ssl.xml -->
+  <xsl:template match="/*[local-name()='config']/*[local-name()='subsystems']/*[local-name()='subsystem' and text()='hawkular-services-undertow.xml']">
+    <xsl:copy>
+      <xsl:text>hawkular-services-undertow-ssl.xml</xsl:text>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- copy everything else as-is -->
+  <xsl:template match="node()|comment()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|comment()|@*" />
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-template-ssl.xsl
+++ b/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-template-ssl.xsl
@@ -21,7 +21,7 @@
 
   <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no" />
 
-  <!-- Add the new security realm -->
+  <!-- Add the new security realms -->
   <xsl:template match="/*[local-name()='server']/*[local-name()='management']/*[local-name()='security-realms']/*[local-name()='security-realm' and contains(@name, 'ManagementRealm')]">
     <xsl:element name="security-realm" namespace="{namespace-uri()}">
       <xsl:attribute name="name">UndertowRealm</xsl:attribute>
@@ -34,6 +34,17 @@
             <xsl:attribute name="key-password">hawkular</xsl:attribute>
             <xsl:attribute name="alias">hawkular</xsl:attribute>
           </xsl:element>
+        </xsl:element>
+      </xsl:element>
+    </xsl:element>
+
+    <xsl:element name="security-realm" namespace="{namespace-uri()}">
+      <xsl:attribute name="name">HawkularAgentRealm</xsl:attribute>
+      <xsl:element name="authentication" namespace="{namespace-uri()}">
+        <xsl:element name="truststore" namespace="{namespace-uri()}">
+          <xsl:attribute name="path">hawkular.keystore</xsl:attribute>
+          <xsl:attribute name="relative-to">jboss.server.config.dir</xsl:attribute>
+          <xsl:attribute name="keystore-password">hawkular</xsl:attribute>
         </xsl:element>
       </xsl:element>
     </xsl:element>

--- a/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-template-ssl.xsl
+++ b/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-template-ssl.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xalan="http://xml.apache.org/xalan" version="2.0" exclude-result-prefixes="xalan">
+
+  <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no" />
+
+  <!-- Add the new security realm -->
+  <xsl:template match="/*[local-name()='server']/*[local-name()='management']/*[local-name()='security-realms']/*[local-name()='security-realm' and contains(@name, 'ManagementRealm')]">
+    <xsl:element name="security-realm" namespace="{namespace-uri()}">
+      <xsl:attribute name="name">UndertowRealm</xsl:attribute>
+      <xsl:element name="server-identities" namespace="{namespace-uri()}">
+        <xsl:element name="ssl" namespace="{namespace-uri()}">
+          <xsl:element name="keystore" namespace="{namespace-uri()}">
+            <xsl:attribute name="path">hawkular.keystore</xsl:attribute>
+            <xsl:attribute name="relative-to">jboss.server.config.dir</xsl:attribute>
+            <xsl:attribute name="keystore-password">hawkular</xsl:attribute>
+            <xsl:attribute name="key-password">hawkular</xsl:attribute>
+            <xsl:attribute name="alias">hawkular</xsl:attribute>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+    </xsl:element>
+    <xsl:copy>
+      <xsl:apply-templates select="node()|comment()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- copy everything else as-is -->
+  <xsl:template match="node()|comment()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|comment()|@*" />
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/feature-pack/src/main/xsl/subsystem-templates/hawkular-services-undertow-ssl.xsl
+++ b/feature-pack/src/main/xsl/subsystem-templates/hawkular-services-undertow-ssl.xsl
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xalan="http://xml.apache.org/xalan" version="2.0" exclude-result-prefixes="xalan">
+
+  <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no" />
+
+  <!-- Add https listener -->
+  <xsl:template match="//*[local-name()='config']/*[local-name()='subsystem']/*[local-name()='server' and contains(@name, 'default-server')]/*[local-name()='http-listener']">
+    <xsl:element name="https-listener" namespace="{namespace-uri()}">
+      <xsl:attribute name="name">https</xsl:attribute>
+      <xsl:attribute name="security-realm">UndertowRealm</xsl:attribute>
+      <xsl:attribute name="socket-binding">https</xsl:attribute>
+    </xsl:element>
+    <xsl:copy>
+      <xsl:apply-templates select="node()|comment()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- copy everything else as-is -->
+  <xsl:template match="node()|comment()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|comment()|@*" />
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/feature-pack/src/main/xsl/subsystem-templates/hawkular-wildfly-agent-ssl.xsl
+++ b/feature-pack/src/main/xsl/subsystem-templates/hawkular-wildfly-agent-ssl.xsl
@@ -25,7 +25,7 @@
   <xsl:template match="//*[local-name()='config']/*[local-name()='subsystem']/*[local-name()='storage-adapter' and contains(@type, 'HAWKULAR')]">
     <xsl:copy>
       <xsl:attribute name="use-ssl">true</xsl:attribute>
-      <xsl:attribute name="security-realm">UndertowRealm</xsl:attribute>
+      <xsl:attribute name="security-realm">HawkularAgentRealm</xsl:attribute>
       <xsl:apply-templates select="node()|comment()|@*"/>
     </xsl:copy>
   </xsl:template>

--- a/feature-pack/src/main/xsl/subsystem-templates/hawkular-wildfly-agent-ssl.xsl
+++ b/feature-pack/src/main/xsl/subsystem-templates/hawkular-wildfly-agent-ssl.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xalan="http://xml.apache.org/xalan" version="2.0" exclude-result-prefixes="xalan">
+
+  <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no" />
+
+  <!-- Turn on SSL on agent -->
+  <xsl:template match="//*[local-name()='config']/*[local-name()='subsystem']/*[local-name()='storage-adapter' and contains(@type, 'HAWKULAR')]">
+    <xsl:copy>
+      <xsl:attribute name="use-ssl">true</xsl:attribute>
+      <xsl:attribute name="security-realm">UndertowRealm</xsl:attribute>
+      <xsl:apply-templates select="node()|comment()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- copy everything else as-is -->
+  <xsl:template match="node()|comment()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|comment()|@*" />
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
It also adds the way to pass the credentials as files that can be mounted (~ OpenShift secrets)

There are 3 ways to enable the ssl, each of them assumes the `HAWKULAR_USE_SSL` env variable is set to true:
* The fist method is using the private and public key provided as files located on `/client-secrets/hawkular-services-private.key` and `/client-secrets/hawkular-services-public.pem`

* The second method is via 1 pkcs12 file containing both keys located on `/client-secrets/hawkular-services.pkcs12`

* And the last method is to auto-generate the self-signed certificate for localhost (or perhaps even for a given hostname) by not creating the files described above, but still setting the `HAWKULAR_USE_SSL`.

There are also changes to the `feature-pack` maven module in order to generate the `standalone-ssl.xml` that assumes the keystore file and has everything needed for SSL.

Drawback of this PR is that it installs the openssl package, because we need to be able to accept the external certificate in the pem format and convert them to the pkcs12, which is the format the keytool utility understands.

todo:
* [x] changes to standalone.xml
* [x] generate the self-signed cert for other domain than localhost
* [x] ~this exception is in the server log during the start~ (however, the server starts and is listening on port 8443. I can see the same exception when doing the steps manually as described [here](http://www.hawkular.org/hawkular-services/docs/installation-guide/secure-comm.html)):
```
15:43:09,621 ERROR [org.hawkular.agent.monitor.util.BaseHttpClientGenerator] (Hawkular WildFly Agent Startup Thread) We have a SSLContext without a X509TrustManager.
```

https://issues.jboss.org/browse/HAWKULAR-1200