### PR TITLE
[HAWKULAR-1217] Reducing the waiting times for the very first readiness check.

### DIFF
--- a/openshift/hawkular-services-ephemeral.yaml
+++ b/openshift/hawkular-services-ephemeral.yaml
@@ -160,7 +160,7 @@ objects:
             exec:
               command:
               - /opt/hawkular/bin/ready.sh
-            initialDelaySeconds: 120
+            initialDelaySeconds: 35
             timeoutSeconds: 3
             periodSeconds: 5
             successThreshold: 1
@@ -207,11 +207,11 @@ objects:
           readinessProbe:
             exec:
               command: ['nodetool', 'status']
-            initialDelaySeconds: 30
+            initialDelaySeconds: 15
             timeoutSeconds: 10
             periodSeconds: 15
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6
           livenessProbe:
             exec:
               command: ['nodetool', 'status']

--- a/openshift/hawkular-services-persistent.yaml
+++ b/openshift/hawkular-services-persistent.yaml
@@ -171,7 +171,7 @@ objects:
             exec:
               command:
               - /opt/hawkular/bin/ready.sh
-            initialDelaySeconds: 120
+            initialDelaySeconds: 35
             timeoutSeconds: 3
             periodSeconds: 5
             successThreshold: 1
@@ -222,11 +222,11 @@ objects:
           readinessProbe:
             exec:
               command: ['nodetool', 'status']
-            initialDelaySeconds: 30
+            initialDelaySeconds: 15
             timeoutSeconds: 10
             periodSeconds: 15
             successThreshold: 1
-            failureThreshold: 3
+            failureThreshold: 6
           livenessProbe:
             exec:
               command: ['nodetool', 'status']


### PR DESCRIPTION
with this change I am able to set-up the oc cluster w/ hawkular-services under 2 minutes

before:

start at 16:36:18
ready at 16:38:57
=> 00:02:39

after the change:

start at 16:39:55
ready at 16:41:22
=> 00:01:27

so from 159 seconds it's reduced to 87 seconds on my laptop