### PR TITLE
[BZ-1455877] Resolve real path for cacerts before setting permissions

### DIFF
--- a/docker-dist/src/main/docker/Dockerfile
+++ b/docker-dist/src/main/docker/Dockerfile
@@ -40,7 +40,7 @@ USER root
 RUN yum install --quiet -y openssl && \
     rm -rf /var/cache/yum && \
     mkdir -p ${HAWKULAR_DATA} && \
-    chown -R jboss:jboss ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts && \
+    chown -RH jboss:jboss ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts && \
     chmod -R ugo+rw ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts
 
 VOLUME ["${HAWKULAR_DATA}"]


### PR DESCRIPTION
`$JAVA_HOME/jre/lib/security/cacerts` can be a symlink, thus we need to resolve the real path to change the permissions to that file.