### PR TITLE
Add JDBC events for ManageIQ into command gateway

### DIFF
--- a/hawkular-rest/hawkular-listener/src/main/java/org/hawkular/listener/bus/CommandEventListener.java
+++ b/hawkular-rest/hawkular-listener/src/main/java/org/hawkular/listener/bus/CommandEventListener.java
@@ -58,6 +58,10 @@ public class CommandEventListener extends BasicMessageListener<BasicMessage> {
                 miqEventType = "hawkular_datasource";
                 miqResourceType = "MiddlewareServer";
                 break;
+            case "AddJdbcDriverResponse":
+                miqEventType = "hawkular_jdbc";
+                miqResourceType = "MiddlewareServer";
+                break;
             case "DeployApplicationResponse":
                 miqEventType = "hawkular_deployment";
                 miqResourceType = "MiddlewareServer";
@@ -66,21 +70,14 @@ public class CommandEventListener extends BasicMessageListener<BasicMessage> {
                 miqEventType = "hawkular_datasource_remove";
                 miqResourceType = "MiddlewareServer";
                 break;
-            case "UndeployApplicationResponse": {
-                miqEventType = "hawkular_deployment_remove";
-                miqResourceType = "MiddlewareServer";
-                break;
-            }
-            case "AddJdbcDriverResponse": {
-                miqEventType = "hawkular_jdbc";
-                miqResourceType = "MiddlewareServer";
-                break;
-            }
-            case "RemoveJdbcDriverResponse": {
+            case "RemoveJdbcDriverResponse":
                 miqEventType = "hawkular_jdbc_remove";
                 miqResourceType = "MiddlewareServer";
                 break;
-            }
+            case "UndeployApplicationResponse":
+                miqEventType = "hawkular_deployment_remove";
+                miqResourceType = "MiddlewareServer";
+                break;
             default: {
                 // other EventDestination messages are expected but not currently interesting
                 if (!(msg instanceof EventDestination)) {

--- a/hawkular-rest/hawkular-listener/src/main/java/org/hawkular/listener/bus/CommandEventListener.java
+++ b/hawkular-rest/hawkular-listener/src/main/java/org/hawkular/listener/bus/CommandEventListener.java
@@ -71,6 +71,16 @@ public class CommandEventListener extends BasicMessageListener<BasicMessage> {
                 miqResourceType = "MiddlewareServer";
                 break;
             }
+            case "AddJdbcDriverResponse": {
+                miqEventType = "hawkular_jdbc";
+                miqResourceType = "MiddlewareServer";
+                break;
+            }
+            case "RemoveJdbcDriverResponse": {
+                miqEventType = "hawkular_jdbc_remove";
+                miqResourceType = "MiddlewareServer";
+                break;
+            }
             default: {
                 // other EventDestination messages are expected but not currently interesting
                 if (!(msg instanceof EventDestination)) {


### PR DESCRIPTION
Add events into the command gateway so they are  visible to ManageIQ

Related to: https://github.com/ManageIQ/manageiq-providers-hawkular/pull/71