### PR TITLE
HAWKULAR-1319: all the agent to connect to wildfly in our docker image

### DIFF
--- a/docker-dist/src/main/docker/Dockerfile
+++ b/docker-dist/src/main/docker/Dockerfile
@@ -41,7 +41,8 @@ RUN yum install --quiet -y openssl && \
     rm -rf /var/cache/yum && \
     mkdir -p ${HAWKULAR_DATA} && \
     chown -RH jboss:jboss ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts && \
-    chmod -R ugo+rw ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts
+    chmod -R ugo+rw ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts && \
+    chmod -R a+x ${JBOSS_HOME}
 
 VOLUME ["${HAWKULAR_DATA}"]
 


### PR DESCRIPTION
Wildlfy relies on using file permissions to determine if a local connection to DMR should be authorized or not (if the user permission to create ${JBOSS_HOME}/tmp and create a file there, they can be authenticated).

Since OpenShift runs the container as a user from a range (by default) we need to allow any user to create the file required for a local DMR connection. This will allow the agent to monitor the Hawkular Services instance.