### PR TITLE
HAWKULAR-1315: remove ImagePullPolicy from templates and use defaults

### DIFF
--- a/openshift/hawkular-services-ephemeral.yaml
+++ b/openshift/hawkular-services-ephemeral.yaml
@@ -143,7 +143,6 @@ objects:
             value: ${HAWKULAR_USER}
           - name: HAWKULAR_PASSWORD
             value: ${HAWKULAR_PASSWORD}
-          imagePullPolicy: IfNotPresent
           name: hawkular-services
           volumeMounts:
           - name: h-services-data
@@ -198,7 +197,6 @@ objects:
       spec:
         containers:
         - image: ${CASSANDRA_IMAGE}
-          imagePullPolicy: Always
           name: hawkular-cassandra
           volumeMounts:
           - name: cassandra-data

--- a/openshift/hawkular-services-persistent-ssl.yaml
+++ b/openshift/hawkular-services-persistent-ssl.yaml
@@ -160,7 +160,6 @@ objects:
             value: ${HAWKULAR_USER}
           - name: HAWKULAR_PASSWORD
             value: ${HAWKULAR_PASSWORD}
-          imagePullPolicy: IfNotPresent
           name: hawkular-services
           volumeMounts:
           - name: h-services-data
@@ -222,7 +221,6 @@ objects:
       spec:
         containers:
         - image: ${CASSANDRA_IMAGE}
-          imagePullPolicy: Always
           name: hawkular-cassandra
           env:
           - name: DATA_VOLUME

--- a/openshift/hawkular-services-persistent.yaml
+++ b/openshift/hawkular-services-persistent.yaml
@@ -152,7 +152,6 @@ objects:
             value: ${HAWKULAR_USER}
           - name: HAWKULAR_PASSWORD
             value: ${HAWKULAR_PASSWORD}
-          imagePullPolicy: IfNotPresent
           name: hawkular-services
           volumeMounts:
           - name: h-services-data
@@ -208,7 +207,6 @@ objects:
       spec:
         containers:
         - image: ${CASSANDRA_IMAGE}
-          imagePullPolicy: Always
           name: hawkular-cassandra
           env:
           - name: DATA_VOLUME


### PR DESCRIPTION
If we set the pull policy to 'IfNotPresent' then it means if we will never update our image (which is problematic if you are using 'latest' since it wont actually download a newer image)

The better option is to usually not set the 'ImagePullPolicy' directly. If the image is 'latest' it will automatically set the 'ImagePullPolicy' to 'Always'. Otherwise it will use 'IfNotPresent'



