### PR TITLE
Remove unused Caches and Destinations from config

### DIFF
--- a/feature-pack-parent/feature-pack/src/main/xsl/subsystem-templates/hawkular-services-infinispan.xsl
+++ b/feature-pack-parent/feature-pack/src/main/xsl/subsystem-templates/hawkular-services-infinispan.xsl
@@ -24,14 +24,6 @@
   <xsl:template match="//*[local-name()='config']/*[local-name()='supplement' and @name='default']/*[local-name()='replacement' and @placeholder='CACHE-CONTAINERS']">
     <xsl:copy>
       <xsl:apply-templates select="node()|comment()|@*" />
-      <cache-container name="hawkular-alerts" default-cache="triggers" statistics-enabled="true">
-        <local-cache name="partition"/>
-        <local-cache name="triggers"/>
-        <local-cache name="data"/>
-        <local-cache name="publish"/>
-        <local-cache name="dataIds"/>
-        <local-cache name="globalActions"/>
-      </cache-container>
       <cache-container name="hawkular-services" default-cache="backfill" statistics-enabled="true">
         <local-cache name="backfill"/>
       </cache-container>

--- a/feature-pack-parent/feature-pack/src/main/xsl/subsystem-templates/hawkular-services-messaging-activemq.xsl
+++ b/feature-pack-parent/feature-pack/src/main/xsl/subsystem-templates/hawkular-services-messaging-activemq.xsl
@@ -25,13 +25,6 @@
     <xsl:copy>
       <xsl:apply-templates select="node()|comment()|@*" />
     </xsl:copy>
-
-    <xsl:comment> Alerts </xsl:comment>
-    <jms-topic name="HawkularAlertData" entries="java:/topic/HawkularAlertData"/>
-    <jms-queue name="HawkularAlertsPluginsQueue" entries="java:/queue/HawkularAlertsPluginsQueue"/>
-    <jms-queue name="HawkularAlertsActionsResponseQueue" entries="java:/queue/HawkularAlertsActionsResponseQueue"/>
-    <jms-topic name="HawkularAlertsActionsTopic" entries="java:/topic/HawkularAlertsActionsTopic"/>
-
     <xsl:comment> Hawkular/Glue </xsl:comment>
     <jms-topic name="HawkularCommandEvent" entries="java:/queue/HawkularCommandEvent"/>
   </xsl:template>


### PR DESCRIPTION
Alerting 1.8 manages configuration outside standalone.xml, so those caches are redundant and creates noise also in agent.
Also removing unused destinations, we don't communicate alerting through the bus.