### PR TITLE
HAWKULAR-1336 - configure build to fix issue with dev profile

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -101,9 +101,6 @@
     <profile>
       <!-- A profile to build a development distro -->
       <id>dev</id>
-      <properties>
-        <dozip>false</dozip>
-      </properties>
 
       <build>
         <plugins>
@@ -144,10 +141,10 @@
       </build>
     </profile>
     <profile>
-      <id>dozip</id>
+      <id>dist</id>
       <activation>
         <property>
-          <name>dozip</name>
+          <name>dist</name>
           <value>true</value>
         </property>
         <activeByDefault>true</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,7 @@
     <module>hawkular-rest</module>
     <module>dist</module>
     <module>feature-pack-parent</module>
-    <module>itest</module>
     <module>hawkular-status</module>
-    <module>docker-dist</module>
   </modules>
 
   <scm>
@@ -265,6 +263,7 @@
             <excludes combine.children="append">
               <exclude>openshift/cert-examples/**/*.pem</exclude>
               <exclude>openshift/cert-examples/**/*.key</exclude>
+              <exclude>docker-dist/.dockerignore</exclude>
             </excludes>
           </configuration>
         </plugin>
@@ -273,6 +272,20 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>dist</id>
+      <activation>
+        <property>
+          <name>dist</name>
+          <value>true</value>
+        </property>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>itest</module>
+        <module>docker-dist</module>
+      </modules>
+    </profile>
     <profile>
       <!-- A profile to build a development distro -->
       <id>dev</id>


### PR DESCRIPTION
If the "dev" profile is activated, generation of the hawkular services
dist zip is skipped to speed up the build.  The itest and docker-dist
modules are dependent on this zip, so the build will fail if the zip
is not in the local maven repo.  This change causes the itest and
docker-dist modules to be skipped completely if the "dev" profile is active.