### PR TITLE
Avoiding SSL usage for the agent inside container

### DIFF
--- a/docker-dist/src/main/docker/docker-assembly.xml
+++ b/docker-dist/src/main/docker/docker-assembly.xml
@@ -82,7 +82,7 @@
       <outputDirectory>${docker.jboss_home}/standalone/configuration</outputDirectory>
     </file>
     <file>
-      <source>${project.build.directory}/${project.build.finalName}/standalone/configuration/standalone-ssl.xml</source>
+      <source>${project.build.directory}/${project.build.finalName}/standalone/configuration/standalone-docker-ssl.xml</source>
       <outputDirectory>${docker.jboss_home}/standalone/configuration</outputDirectory>
     </file>
     <file>

--- a/docker-dist/src/main/resources/cert_utils.sh
+++ b/docker-dist/src/main/resources/cert_utils.sh
@@ -37,12 +37,10 @@ add_cert_as_trusted() {
   rm ${KEYSTORE_HOME}/hawkular.cert
 }
 
-# add the security realm, HTTPS listener and turn SSL for agent
+# add the security realm, HTTPS listener.
 use_standalone_ssl_config() {
   cp ${JBOSS_HOME}/standalone/configuration/standalone.xml ${JBOSS_HOME}/standalone/configuration/standalone-orig.xml
-  cp ${JBOSS_HOME}/standalone/configuration/standalone-ssl.xml ${JBOSS_HOME}/standalone/configuration/standalone.xml
-  cp ${JBOSS_HOME}/standalone/configuration/hawkular-javaagent-config.yaml ${JBOSS_HOME}/standalone/configuration/hawkular-javaagent-config-orig.yaml
-  cp ${JBOSS_HOME}/standalone/configuration/hawkular-javaagent-config-ssl.yaml ${JBOSS_HOME}/standalone/configuration/hawkular-javaagent-config.yaml
+  cp ${JBOSS_HOME}/standalone/configuration/standalone-docker-ssl.xml ${JBOSS_HOME}/standalone/configuration/standalone.xml
 }
 
 add_certificate() {

--- a/feature-pack/feature-pack-build.xml
+++ b/feature-pack/feature-pack-build.xml
@@ -26,6 +26,7 @@
   <config>
     <standalone template="configuration/standalone/hawkular-services-template.xml" subsystems="configuration/standalone/hawkular-services-subsystems.xml" output-file="standalone/configuration/standalone.xml" />
     <standalone template="configuration/standalone/hawkular-services-template-ssl.xml" subsystems="configuration/standalone/hawkular-services-subsystems-ssl.xml" output-file="standalone/configuration/standalone-ssl.xml" />
+    <standalone template="configuration/standalone/hawkular-services-template-docker-ssl.xml" subsystems="configuration/standalone/hawkular-services-subsystems-ssl.xml" output-file="standalone/configuration/standalone-docker-ssl.xml" />
   </config>
 
   <copy-artifacts>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -239,6 +239,21 @@
 
                 <transformationSet>
                   <dir>${project.build.directory}/feature-pack-resources</dir>
+                  <stylesheet>${basedir}/src/main/xsl/configuration/standalone/hawkular-services-template-docker-ssl.xsl</stylesheet>
+                  <includes>
+                    <include>configuration/standalone/hawkular-services-template.xml</include>
+                  </includes>
+                  <outputDir>${project.build.directory}/feature-pack-resources</outputDir>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.RegExpFileMapper">
+                      <pattern>^.*$</pattern>
+                      <replacement>configuration/standalone/hawkular-services-template-docker-ssl.xml</replacement>
+                    </fileMapper>
+                  </fileMappers>
+                </transformationSet>
+
+                <transformationSet>
+                  <dir>${project.build.directory}/feature-pack-resources</dir>
                   <stylesheet>${basedir}/src/main/xsl/subsystem-templates/hawkular-services-logging.xsl</stylesheet>
                   <includes>
                     <include>subsystem-templates/hawkular-nest-logging.xml</include>

--- a/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-template-docker-ssl.xsl
+++ b/feature-pack/src/main/xsl/configuration/standalone/hawkular-services-template-docker-ssl.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xalan="http://xml.apache.org/xalan" version="2.0" exclude-result-prefixes="xalan">
+
+  <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no" />
+
+  <!-- Add the new security realms -->
+  <xsl:template match="/*[local-name()='server']/*[local-name()='management']/*[local-name()='security-realms']/*[local-name()='security-realm' and contains(@name, 'ManagementRealm')]">
+    <xsl:element name="security-realm" namespace="{namespace-uri()}">
+      <xsl:attribute name="name">UndertowRealm</xsl:attribute>
+      <xsl:element name="server-identities" namespace="{namespace-uri()}">
+        <xsl:element name="ssl" namespace="{namespace-uri()}">
+          <xsl:element name="keystore" namespace="{namespace-uri()}">
+            <xsl:attribute name="path">hawkular.keystore</xsl:attribute>
+            <xsl:attribute name="relative-to">jboss.server.config.dir</xsl:attribute>
+            <xsl:attribute name="keystore-password">hawkular</xsl:attribute>
+            <xsl:attribute name="key-password">hawkular</xsl:attribute>
+            <xsl:attribute name="alias">hawkular</xsl:attribute>
+          </xsl:element>
+        </xsl:element>
+      </xsl:element>
+    </xsl:element>
+    <xsl:copy>
+      <xsl:copy-of select="node()|comment()|@*" />
+    </xsl:copy>
+  </xsl:template>
+
+
+  <!-- copy everything else as-is -->
+  <xsl:template match="node()|comment()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|comment()|@*" />
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
There are some cases when I don't have control of the certificates and can't add localhost SANs, an example is when I use OpenShift Service Serving Certificate Secrets.

I think is safe to not use SSL for this case, even if the SSL is enabled. because all traffic is inside the container, which has the private/public keys of the SSL encryption.

This is just for the case when HAWKULAR_SSL=true, so the other way of seeing this is PR is "setting up the SSL but making sure that agent inside the container still use plain HTTP)