### PR TITLE
Using gosu for execute the SSL certificate import process.

### DIFF
--- a/docker-dist/src/main/docker/Dockerfile
+++ b/docker-dist/src/main/docker/Dockerfile
@@ -22,6 +22,7 @@ MAINTAINER Hawkular Team, hawkular-dev@lists.jboss.org
 ARG agent_enable
 ARG metrics_ttl=21
 ARG the_tag
+ARG GOSU_VERSION=1.10
 
 EXPOSE 8080 8443 8787
 
@@ -40,13 +41,26 @@ ENV HAWKULAR_BACKEND=cassandra \
     HAWKULAR_KEYPAIR_FILENAME="/client-secrets/hawkular-services.pkcs12"
 
 USER root
-RUN yum install --quiet -y openssl && \
-    rm -rf /var/cache/yum && \
-    mkdir -p ${HAWKULAR_DATA} && \
-    chown -RH jboss:jboss ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts && \
-    chmod -R ugo+rw ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts
+RUN set -ex; \
+    yum install --quiet -y openssl;\
+    rm -rf /var/cache/yum; \
+    mkdir -p ${HAWKULAR_DATA}; \
+    chown -RH jboss:jboss ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts; \
+    chmod -R ugo+rw ${JBOSS_HOME}/{standalone,domain} ${HAWKULAR_DATA} $JAVA_HOME/jre/lib/security/cacerts; \
+    yum -y install epel-release; \
+    yum -y install wget dpkg; \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /tmp/gosu.asc /usr/bin/gosu; \
+    rm -r "$GNUPGHOME" /tmp/gosu.asc; \
+    chmod +x /usr/bin/gosu; \
+    gosu nobody true; \
+    yum -y remove wget dpkg; \
+    yum clean all
 
 VOLUME ["${HAWKULAR_DATA}"]
 
-USER jboss
-CMD /opt/hawkular/bin/startcmd.sh
+CMD /opt/hawkular/bin/entrypoint.sh

--- a/docker-dist/src/main/docker/docker-assembly.xml
+++ b/docker-dist/src/main/docker/docker-assembly.xml
@@ -54,6 +54,11 @@
       <fileMode>755</fileMode>
     </file>
     <file>
+      <source>src/main/resources/entrypoint.sh</source>
+      <outputDirectory>${docker.hawkular_home}/bin</outputDirectory>
+      <fileMode>755</fileMode>
+    </file>
+    <file>
       <source>src/main/resources/ready.sh</source>
       <outputDirectory>${docker.hawkular_home}/bin</outputDirectory>
       <fileMode>755</fileMode>

--- a/docker-dist/src/main/resources/cert_utils.sh
+++ b/docker-dist/src/main/resources/cert_utils.sh
@@ -43,6 +43,11 @@ use_standalone_ssl_config() {
   cp ${JBOSS_HOME}/standalone/configuration/standalone-docker-ssl.xml ${JBOSS_HOME}/standalone/configuration/standalone.xml
 }
 
+set_certificate_permissions() {
+  chown jboss:jboss ${KEYSTORE_HOME}/hawkular.keystore
+  chmod ugo+rw ${KEYSTORE_HOME}/hawkular.keystore
+}
+
 add_certificate() {
   if [[ ${HAWKULAR_USE_SSL} = "true" ]]; then
     local _public_key=${HAWKULAR_PUBLIC_KEY_FILENAME}
@@ -93,6 +98,6 @@ add_certificate() {
 
       add_cert_as_trusted
     fi
-    use_standalone_ssl_config
+    set_certificate_permissions
   fi
 }

--- a/docker-dist/src/main/resources/entrypoint.sh
+++ b/docker-dist/src/main/resources/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2017 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Add the certificate using root
+# This fixes permission issues on the volumen and the java cacert
+source $(dirname "$0")/cert_utils.sh
+add_certificate
+
+# Run the rest of the process as a jboss user.
+gosu jboss /opt/hawkular/bin/startcmd.sh "$@"

--- a/docker-dist/src/main/resources/startcmd.sh
+++ b/docker-dist/src/main/resources/startcmd.sh
@@ -137,7 +137,7 @@ main() {
   source $(dirname "$0")/cert_utils.sh
   get_credentials
   create_user
-  add_certificate
+  use_standalone_ssl_config
   check_cassandra
   run_hawkular_services "$@"
 }


### PR DESCRIPTION
This is for fix BZ 1515883

https://bugzilla.redhat.com/show_bug.cgi?id=1515883

- First I do all the certificate import process as root,
- then I use `gosu` to switch to `jboss` user and execute the rest of the process (including wildly with hawkular-services deploys)


In this way I avoid all issues with permissions on the volume, This hasn't failed on my machine because I have UID `1000` on my user. (same as `jboss` user on the image), but if the host user UID doesn't match with `jboss` the ownership of the certificates on the volume could be another user (event a non-existing user on the container) and the `jboss` user won't be able to read and import the certificates to the keystore file.