### PR TITLE
Increase the liveness and readiness probes timeout

### DIFF
--- a/openshift/hawkular-services-ephemeral.yaml
+++ b/openshift/hawkular-services-ephemeral.yaml
@@ -151,14 +151,14 @@ objects:
               command:
               - /opt/hawkular/bin/ready.sh
             initialDelaySeconds: 180
-            timeoutSeconds: 3
+            timeoutSeconds: 15
           readinessProbe:
             exec:
               command:
               - /opt/hawkular/bin/ready.sh
             initialDelaySeconds: 35
-            timeoutSeconds: 3
-            periodSeconds: 5
+            timeoutSeconds: 15
+            periodSeconds: 20
             successThreshold: 1
             failureThreshold: 12
           resources:

--- a/openshift/hawkular-services-persistent.yaml
+++ b/openshift/hawkular-services-persistent.yaml
@@ -170,14 +170,14 @@ objects:
               command:
               - /opt/hawkular/bin/ready.sh
             initialDelaySeconds: 180
-            timeoutSeconds: 3
+            timeoutSeconds: 15
           readinessProbe:
             exec:
               command:
               - /opt/hawkular/bin/ready.sh
             initialDelaySeconds: 35
-            timeoutSeconds: 3
-            periodSeconds: 5
+            timeoutSeconds: 15
+            periodSeconds: 20
             successThreshold: 1
             failureThreshold: 12
           resources:


### PR DESCRIPTION
This PR increases the timeout of liveness probe and readiness probe in order to avoid the following exception:

` org.jboss.resteasy.spi.UnhandledException: RESTEASY003770: Response is committed, can't handle exception connection reset by peer` 

This exception happens because the timeout is too small and the request takes time under some conditions and the probe interrupts the request. 