### PR TITLE
HAWKULAR-1347 Fix AgentITest assert result

### DIFF
--- a/itest/src/test/java/org/hawkular/services/rest/test/AgentITest.java
+++ b/itest/src/test/java/org/hawkular/services/rest/test/AgentITest.java
@@ -64,7 +64,7 @@ public class AgentITest extends AbstractTestBase {
                                                 "[%s] should have a resource with an id of [%s]",
                                                 testResponse.getRequest(), wfServerId));
                                 Assert.assertTrue(dequote(foundResources.get("config").get("Server State").toString())
-                                        .equals("running"),
+                                        .equals("reload-required"),
                                         String.format(
                                                 "[%s] should have a config 'Server State' with value 'running'",
                                                 foundResources.get("config")));


### PR DESCRIPTION
This is to set Hawkular Services in a good state.
Once, agent is updated and server is in "running" state again, this test will fail and we will update the result.

